### PR TITLE
Automate GitHub release and PyPI upload

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,15 +8,14 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,47 @@
+name: Release and publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  # test:
+    # uses: ./.github/workflows/python-app.yml
+
+  create-release:
+    # needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Create a release
+        uses: elgohr/Github-Release-Action@v5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Release ${{ github.ref_name }}"
+          prerelease: true
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://test.pypi.org/project/example-package-yujiyokoo/
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -26,8 +26,8 @@ jobs:
     needs: [test, create-release]
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/project/eqlpy/
+      name: pypi
+      url: https://pypi.org/project/eqlpy/
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -42,9 +42,8 @@ jobs:
           pip install build
       - name: Build package
         run: python -m build
-      - name: Publish package distributions to TestPyPI
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
           verbose: true
 

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -6,11 +6,10 @@ on:
       - 'v*'
 
 jobs:
-  # test:
-    # uses: ./.github/workflows/python-app.yml
-
+  test:
+    uses: ./.github/workflows/python-app.yml
   create-release:
-    # needs: test
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,10 +23,11 @@ jobs:
           prerelease: true
   pypi-publish:
     name: Upload release to PyPI
+    needs: [test, create-release]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
-      url: https://test.pypi.org/project/example-package-yujiyokoo/
+      name: testpypi
+      url: https://test.pypi.org/project/eqlpy/
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -42,6 +42,9 @@ jobs:
           pip install build
       - name: Build package
         run: python -m build
-      - name: Publish package distributions to PyPI
+      - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 Currently, eqlpy supports either of the following database packages:
 
-* psycopg 3
+* psycopg 3 or psycopg 2
 * sqlalchemy + psycopg 2
 
 For code examples of storing and querying encrypted data with [CipherStash Proxy](https://cipherstash.com/docs/getting-started/cipherstash-proxy) using those packages, refer to [examples directory](examples/) and [integration tests](tests/integration/).
@@ -183,6 +183,18 @@ print(eql_row.row)
     'data': {'key': 'value'}
 }
 ```
+
+## Release
+
+This project has been set up to use [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) in PyPI from GitHub Actions.
+
+To make a GitHub release and publish to PyPI do the following steps:
+
+* Update the version in pyproject.toml in `main` branch (eg. "1.2.3")
+* Make a tag of the same version prefixed with "v" (eg. "v1.2.3"), and push
+  * `git tag v1.2.3`
+  * `git push v1.2.3`
+* `release-and-publish.yml` workflow will create a GitHub release, and publish the package to PyPI
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "eqlpy"
-version = "0.0.3a1"
+version = "0.0.3a11"
 authors = [
   { name="CipherStash", email="yuji@cipherstash.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "eqlpy"
-version = "0.0.3a11"
+version = "1.0.0"
 authors = [
   { name="CipherStash", email="yuji@cipherstash.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "eqlpy"
-version = "1.0.0"
+version = "0.0.3a1"
 authors = [
   { name="CipherStash", email="yuji@cipherstash.com" },
 ]


### PR DESCRIPTION
Add automates:

* Creating GitHub releases
* PyPI publishing

Upon pushing a tag prefixed with 'v', the `release-and-publish.yml` workflow will automatically create a release, and publish to PyPI