### PR TITLE
Add Django ORM support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest sqlalchemy psycopg psycopg2 django
+          pip install flake8 pytest sqlalchemy psycopg2 django
+          pip uninstall -y psycopg # Django + psycopg 3 currently has issues
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest sqlalchemy psycopg2
+          pip install flake8 pytest sqlalchemy psycopg psycopg2 django
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ These are the common prerequisites for all variations. See below for specific va
 * Docker
 * Docker compose
 * CipherStash account
-* (Optinal) direnv or other tools to load environment variables from a file
+* (Optional) direnv or other tools to load environment variables from a file
 
 ### psycopg example
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,18 +2,31 @@
 
 This directory contains short examples of using eqlpy to store and query encrypted records.
 
+Currently, there are 3 variations of supported ORMs and database driver combinations.
+
 ## Prerequisites
 
-### psycopg example
+These are the common prerequisites for all variations. See below for specific variations.
 
 * Python 3
 * Docker
 * Docker compose
 * CipherStash account
-* Supported database driver/ORM, either of:
-    * sqlalchemy + psycopg2
-    * psycopg 3
 * (Optinal) direnv or other tools to load environment variables from a file
+
+### psycopg example
+
+* psycopg 3
+
+### sqlalchemy example
+
+Please note currently pscyopg2 is required with the sqlalchemy example
+
+* sqlalchemy (2.0 or above recommended) + psycopg2
+
+### Django example
+
+* Django (5.1 or above recommended) + psycopg2
 
 ## Setup
 
@@ -37,6 +50,7 @@ This directory contains short examples of using eqlpy to store and query encrypt
 At this point, you should be able to run the examples.
 
 * If you have sqlalchemy and psycopg2, run `python examples/sqlalchemy_examples.py`
+* If you have Django and psycopg2, run `python examples/django_examples.py`
 * If you have psycopg 3, run: `python examples/psycopg_examples.py`
 
 and follow the prompt/instructions.

--- a/examples/django_examples.py
+++ b/examples/django_examples.py
@@ -7,6 +7,7 @@ from eqlpy.eqldjango import *
 from datetime import date
 import os
 
+
 class TestSettings:
     pg_password = os.getenv("PGPASSWORD", "postgres")
     pg_user = os.getenv("PGUSER", "postgres")
@@ -38,25 +39,34 @@ if not settings.configured:
 
 django.setup()
 
+
 class Example(models.Model):
     encrypted_int = EncryptedInt(table="examples", column="encrypted_int", null=True)
     encrypted_boolean = EncryptedBoolean(
         table="examples", column="encrypted_boolean", null=True
     )
     encrypted_date = EncryptedDate(table="examples", column="encrypted_date", null=True)
-    encrypted_float = EncryptedFloat(table="examples", column="encrypted_float", null=True)
+    encrypted_float = EncryptedFloat(
+        table="examples", column="encrypted_float", null=True
+    )
     encrypted_utf8_str = EncryptedText(
         table="examples", column="encrypted_utf8_str", null=True
     )
-    encrypted_jsonb = EncryptedJsonb(table="examples", column="encrypted_jsonb", null=True)
+    encrypted_jsonb = EncryptedJsonb(
+        table="examples", column="encrypted_jsonb", null=True
+    )
 
     class Meta:
         app_label = "eqlpy.eqldjango"
         db_table = "examples"
+
     def __str__(self):
-        return f"Example(id={self.id}, int={self.encrypted_int}, bool={self.encrypted_boolean}, " \
-               f"date={self.encrypted_date}, float={self.encrypted_float}, " \
-               f"str='{self.encrypted_utf8_str}', jsonb={self.encrypted_jsonb})"
+        return (
+            f"Example(id={self.id}, int={self.encrypted_int}, bool={self.encrypted_boolean}, "
+            f"date={self.encrypted_date}, float={self.encrypted_float}, "
+            f"str='{self.encrypted_utf8_str}', jsonb={self.encrypted_jsonb})"
+        )
+
 
 def insert_example_records():
     print("\n\nInserting an example records...", end="")
@@ -65,7 +75,7 @@ def insert_example_records():
     example1 = Example(
         encrypted_int=1,
         encrypted_boolean=True,
-        encrypted_utf8_str='string123',
+        encrypted_utf8_str="string123",
         encrypted_date=date(2024, 1, 1),
         encrypted_float=1.1,
         encrypted_jsonb={"key": ["value"], "num": 1, "cat": "a"},
@@ -75,7 +85,7 @@ def insert_example_records():
     example2 = Example(
         encrypted_int=-1,
         encrypted_boolean=False,
-        encrypted_utf8_str='another_example',
+        encrypted_utf8_str="another_example",
         encrypted_date=date(2024, 1, 2),
         encrypted_float=2.1,
         encrypted_jsonb={"num": 2, "cat": "b"},
@@ -85,7 +95,7 @@ def insert_example_records():
     example3 = Example(
         encrypted_int=0,
         encrypted_boolean=False,
-        encrypted_utf8_str='yet_another',
+        encrypted_utf8_str="yet_another",
         encrypted_date=date(2024, 1, 3),
         encrypted_float=5.0,
         encrypted_jsonb={"num": 3, "cat": "b"},
@@ -96,8 +106,10 @@ def insert_example_records():
 
     return [example1, example2, example3]
 
+
 def print_instructions():
-    print("""
+    print(
+        """
 In another terminal window, you can check the data on CipherStash Proxy with (assuming you are using default setting):
 
   $ psql -h localhost -p 6432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
@@ -106,50 +118,50 @@ Also you can check what is really stored on PostgreSQL with:
 
   $ psql -h localhost -p 5432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
 
-""")
-    print(f"If you get prompted for password, use '{TestSettings.pg_password}' (without quotes).\n")
+"""
+    )
+    print(
+        f"If you get prompted for password, use '{TestSettings.pg_password}' (without quotes).\n"
+    )
+
 
 def query_example_match():
-    print("\nQuery example for partial Match of 'string1' in examples.encrypted_utf8_str:")
+    print(
+        "\nQuery example for partial Match of 'string1' in examples.encrypted_utf8_str:"
+    )
     term = EqlText("string", "examples", "encrypted_utf8_str").to_db_format("match")
     record = Example.objects.filter(
-        Q(
-            CsContains(CsMatchV1(F("encrypted_utf8_str")), CsMatchV1(Value(term)))
-        )
-
+        Q(CsContains(CsMatchV1(F("encrypted_utf8_str")), CsMatchV1(Value(term))))
     )[0]
 
     print()
     print(f"  Record found: {record}")
     print()
+
 
 def query_example_ore():
     print("\nQuery example for 3.0 < examples.encrypted_float:")
     term = EqlFloat(3.0, "examples", "encrypted_float").to_db_format("ore")
     record = Example.objects.filter(
-        Q(
-             CsGt(CsOre648V1(F("encrypted_float")), CsOre648V1(Value(term)))
-        )
+        Q(CsGt(CsOre648V1(F("encrypted_float")), CsOre648V1(Value(term))))
     )[0]
 
     print()
     print(f"  Record found: {record}")
     print()
 
+
 def query_example_json_contains():
-    print("\nQuery example for examples.encrypted_json @> {\"key:\": []} :")
-    term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format(
-        "ste_vec"
-    )
+    print('\nQuery example for examples.encrypted_json @> {"key:": []} :')
+    term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format("ste_vec")
     record = Example.objects.get(
-        Q(
-            CsContains(CsSteVecV1(F("encrypted_jsonb")), CsSteVecV1(Value(term)))
-        )
+        Q(CsContains(CsSteVecV1(F("encrypted_jsonb")), CsSteVecV1(Value(term))))
     )
 
     print()
     print(f"  Record found: {record}")
     print()
+
 
 def main():
     # refresh config just in case
@@ -178,6 +190,7 @@ def main():
     input("Press Enter to continue.")
 
     print("\n=== End of examples ===\n")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/django_examples.py
+++ b/examples/django_examples.py
@@ -1,0 +1,183 @@
+import django
+from django.conf import settings
+from django.db import models, connection
+from django.db.models import Q, F, Value, Count
+from eqlpy.eql_types import EqlFloat, EqlText, EqlJsonb
+from eqlpy.eqldjango import *
+from datetime import date
+import os
+
+class TestSettings:
+    pg_password = os.getenv("PGPASSWORD", "postgres")
+    pg_user = os.getenv("PGUSER", "postgres")
+    pg_host = os.getenv("PGHOST", "localhost")
+    pg_port = os.getenv("PGPORT", "6432")
+    pg_db = os.getenv("PGDATABASE", "eqlpy_example")
+    secret_key = os.getenv("SECRET_KEY", "test_secret_key")
+
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        INSTALLED_APPS=[
+            "eqlpy.eqldjango",
+        ],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.postgresql",
+                "NAME": f"{TestSettings.pg_db}",
+                "USER": f"{TestSettings.pg_user}",
+                "PASSWORD": f"{TestSettings.pg_password}",
+                "HOST": f"{TestSettings.pg_host}",
+                "PORT": f"{TestSettings.pg_port}",
+            }
+        },
+        SECRET_KEY=f"{TestSettings.secret_key}",
+        AUTOCOMMIT=False,
+    )
+
+django.setup()
+
+class Example(models.Model):
+    encrypted_int = EncryptedInt(table="examples", column="encrypted_int", null=True)
+    encrypted_boolean = EncryptedBoolean(
+        table="examples", column="encrypted_boolean", null=True
+    )
+    encrypted_date = EncryptedDate(table="examples", column="encrypted_date", null=True)
+    encrypted_float = EncryptedFloat(table="examples", column="encrypted_float", null=True)
+    encrypted_utf8_str = EncryptedText(
+        table="examples", column="encrypted_utf8_str", null=True
+    )
+    encrypted_jsonb = EncryptedJsonb(table="examples", column="encrypted_jsonb", null=True)
+
+    class Meta:
+        app_label = "eqlpy.eqldjango"
+        db_table = "examples"
+    def __str__(self):
+        return f"Example(id={self.id}, int={self.encrypted_int}, bool={self.encrypted_boolean}, " \
+               f"date={self.encrypted_date}, float={self.encrypted_float}, " \
+               f"str='{self.encrypted_utf8_str}', jsonb={self.encrypted_jsonb})"
+
+def insert_example_records():
+    print("\n\nInserting an example records...", end="")
+    Example.objects.all().delete()
+
+    example1 = Example(
+        encrypted_int=1,
+        encrypted_boolean=True,
+        encrypted_utf8_str='string123',
+        encrypted_date=date(2024, 1, 1),
+        encrypted_float=1.1,
+        encrypted_jsonb={"key": ["value"], "num": 1, "cat": "a"},
+    )
+    example1.save()
+
+    example2 = Example(
+        encrypted_int=-1,
+        encrypted_boolean=False,
+        encrypted_utf8_str='another_example',
+        encrypted_date=date(2024, 1, 2),
+        encrypted_float=2.1,
+        encrypted_jsonb={"num": 2, "cat": "b"},
+    )
+    example2.save()
+
+    example3 = Example(
+        encrypted_int=0,
+        encrypted_boolean=False,
+        encrypted_utf8_str='yet_another',
+        encrypted_date=date(2024, 1, 3),
+        encrypted_float=5.0,
+        encrypted_jsonb={"num": 3, "cat": "b"},
+    )
+    example3.save()
+
+    print("done\n")
+
+    return [example1, example2, example3]
+
+def print_instructions():
+    print("""
+In another terminal window, you can check the data on CipherStash Proxy with (assuming you are using default setting):
+
+  $ psql -h localhost -p 6432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
+
+Also you can check what is really stored on PostgreSQL with:
+
+  $ psql -h localhost -p 5432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
+
+""")
+    print(f"If you get prompted for password, use '{TestSettings.pg_password}' (without quotes).\n")
+
+def query_example_match():
+    print("\nQuery example for partial Match of 'string1' in examples.encrypted_utf8_str:")
+    term = EqlText("string", "examples", "encrypted_utf8_str").to_db_format("match")
+    record = Example.objects.filter(
+        Q(
+            CsContains(CsMatchV1(F("encrypted_utf8_str")), CsMatchV1(Value(term)))
+        )
+
+    )[0]
+
+    print()
+    print(f"  Record found: {record}")
+    print()
+
+def query_example_ore():
+    print("\nQuery example for 3.0 < examples.encrypted_float:")
+    term = EqlFloat(3.0, "examples", "encrypted_float").to_db_format("ore")
+    record = Example.objects.filter(
+        Q(
+             CsGt(CsOre648V1(F("encrypted_float")), CsOre648V1(Value(term)))
+        )
+    )[0]
+
+    print()
+    print(f"  Record found: {record}")
+    print()
+
+def query_example_json_contains():
+    print("\nQuery example for examples.encrypted_json @> {\"key:\": []} :")
+    term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format(
+        "ste_vec"
+    )
+    record = Example.objects.get(
+        Q(
+            CsContains(CsSteVecV1(F("encrypted_jsonb")), CsSteVecV1(Value(term)))
+        )
+    )
+
+    print()
+    print(f"  Record found: {record}")
+    print()
+
+def main():
+    # refresh config just in case
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT cs_refresh_encrypt_config()")
+
+    [e1, e2, e3] = insert_example_records()
+
+    print_instructions()
+    input("Press Enter to continue.")
+    print()
+
+    print("A record looks like this as an Example model instance:\n")
+    print(f"  {e1}")
+    print()
+    input("Press Enter to continue.")
+    print()
+
+    query_example_match()
+    input("Press Enter to continue.")
+
+    query_example_ore()
+    input("Press Enter to continue.")
+
+    query_example_json_contains()
+    input("Press Enter to continue.")
+
+    print("\n=== End of examples ===\n")
+
+if __name__ == "__main__":
+    main()

--- a/examples/psycopg_examples.py
+++ b/examples/psycopg_examples.py
@@ -1,12 +1,24 @@
 import psycopg
 import pprint
 from datetime import datetime
-from eqlpy.eql_types import EqlInt, EqlBool, EqlDate, EqlFloat, EqlText, EqlJsonb, EqlRow
+from eqlpy.eql_types import (
+    EqlInt,
+    EqlBool,
+    EqlDate,
+    EqlFloat,
+    EqlText,
+    EqlJsonb,
+    EqlRow,
+)
+
 
 def connect_to_db():
-    db_string = "host=localhost dbname=eqlpy_example user=postgres password=postgres port=6432"
+    db_string = (
+        "host=localhost dbname=eqlpy_example user=postgres password=postgres port=6432"
+    )
     conn = psycopg.connect(db_string)
     return conn, conn.cursor(row_factory=psycopg.rows.dict_row)
+
 
 def insert_example_record(cur):
     print("\n\nInserting an example record...", end="")
@@ -22,19 +34,23 @@ def insert_example_record(cur):
         "encrypted_jsonb": EqlJsonb(
             {"num": 1, "category": "a", "top": {"nested": ["a", "b", "c"]}},
             "examples",
-            "encrypted_jsonb"
-        )
+            "encrypted_jsonb",
+        ),
     }
 
     insert_query = """
     INSERT INTO examples (encrypted_int, encrypted_boolean, encrypted_date, encrypted_float, encrypted_utf8_str, encrypted_jsonb)
     VALUES (%s, %s, %s, %s, %s, %s)
     """
-    cur.execute(insert_query, tuple(field.to_db_format() for field in example_data.values()))
+    cur.execute(
+        insert_query, tuple(field.to_db_format() for field in example_data.values())
+    )
     print("done\n")
 
+
 def print_instructions():
-    print("""
+    print(
+        """
 In another terminal window, you can check the data on CipherStash Proxy with (assuming you are using default setting):
 
   $ psql -h localhost -p 6432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
@@ -43,7 +59,9 @@ Also you can check what is really stored on PostgreSQL with:
 
   $ psql -h localhost -p 5432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
 
-""")
+"""
+    )
+
 
 def display_eql_row(cur):
     column_function_map = {
@@ -63,8 +81,11 @@ def display_eql_row(cur):
     for f in found:
         pp.pprint(EqlRow(column_function_map, f).row)
 
+
 def query_example(cur):
-    print("\nQuery example for partial Match of 'hello' in examples.encrypted_utf8_str:")
+    print(
+        "\nQuery example for partial Match of 'hello' in examples.encrypted_utf8_str:"
+    )
     cur.execute(
         "SELECT * FROM examples WHERE cs_match_v1(encrypted_utf8_str) @> cs_match_v1(%s)",
         (EqlText("hello", "examples", "encrypted_utf8_str").to_db_format("match"),),
@@ -72,9 +93,14 @@ def query_example(cur):
     found = cur.fetchall()
     for f in found:
         print()
-        print(f"  Text inside the found record: {EqlText.from_parsed_json(f['encrypted_utf8_str'])}")
+        print(
+            f"  Text inside the found record: {EqlText.from_parsed_json(f['encrypted_utf8_str'])}"
+        )
         print()
-        print(f"  Jsonb inside the found record: {EqlJsonb.from_parsed_json(f['encrypted_jsonb'])}")
+        print(
+            f"  Jsonb inside the found record: {EqlJsonb.from_parsed_json(f['encrypted_jsonb'])}"
+        )
+
 
 def main():
     conn, cur = connect_to_db()
@@ -97,6 +123,7 @@ def main():
 
     cur.close()
     conn.close()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/sqlalchemy_examples.py
+++ b/examples/sqlalchemy_examples.py
@@ -1,7 +1,16 @@
 from sqlalchemy.orm import mapped_column, Mapped, sessionmaker
 from sqlalchemy import create_engine, func, select, text
 from eqlpy.eqlalchemy import *
-from eqlpy.eql_types import EqlInt, EqlBool, EqlDate, EqlFloat, EqlText, EqlJsonb, EqlRow
+from eqlpy.eql_types import (
+    EqlInt,
+    EqlBool,
+    EqlDate,
+    EqlFloat,
+    EqlText,
+    EqlJsonb,
+    EqlRow,
+)
+
 
 class Example(BaseModel):
     __tablename__ = "examples"
@@ -47,26 +56,39 @@ class Example(BaseModel):
             ")>"
         )
 
+
 def connect_to_db():
-    engine = create_engine("postgresql://postgres:postgres@localhost:6432/eqlpy_example")
+    engine = create_engine(
+        "postgresql://postgres:postgres@localhost:6432/eqlpy_example"
+    )
     Session = sessionmaker(bind=engine)
     session = Session()
     BaseModel.metadata.create_all(engine)
     return session
+
 
 def insert_example_record(session):
     print("\n\nInserting an example record...", end="")
     session.execute(text("DELETE FROM examples"))
     session.execute(text("SELECT cs_refresh_encrypt_config()"))
 
-    example_data = Example( "hello, world", {"num": 1, "category": "a", "top": {"nested": ["a", "b", "c"]}}, -51, -0.5, date(2024, 11, 19), False)
+    example_data = Example(
+        "hello, world",
+        {"num": 1, "category": "a", "top": {"nested": ["a", "b", "c"]}},
+        -51,
+        -0.5,
+        date(2024, 11, 19),
+        False,
+    )
     session.add(example_data)
 
     print("done\n")
     return example_data
 
+
 def print_instructions():
-    print("""
+    print(
+        """
 In another terminal window, you can check the data on CipherStash Proxy with (assuming you are using default setting):
 
   $ psql -h localhost -p 6432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
@@ -75,23 +97,32 @@ Also you can check what is really stored on PostgreSQL with:
 
   $ psql -h localhost -p 5432 -U postgres -x -c "select * from examples limit 1;" eqlpy_example
 
-""")
+"""
+    )
+
 
 def query_example(session):
-    print("\nQuery example for partial Match of 'hello' in examples.encrypted_utf8_str:")
-    record = session.query(Example).filter(
-                cs_match_v1(Example.encrypted_utf8_str).op("@>")(
-                    cs_match_v1(
-                        EqlText(
-                            "hello", "examples", "encrypted_utf8_str"
-                        ).to_db_format("match")
+    print(
+        "\nQuery example for partial Match of 'hello' in examples.encrypted_utf8_str:"
+    )
+    record = (
+        session.query(Example)
+        .filter(
+            cs_match_v1(Example.encrypted_utf8_str).op("@>")(
+                cs_match_v1(
+                    EqlText("hello", "examples", "encrypted_utf8_str").to_db_format(
+                        "match"
                     )
                 )
-            ).one()
+            )
+        )
+        .one()
+    )
     print()
     print(f"  Text inside the found record: {record.encrypted_utf8_str}")
     print()
     print(f"  Jsonb inside the found record: {record.encrypted_jsonb}")
+
 
 def main():
     session = connect_to_db()
@@ -114,6 +145,7 @@ def main():
     print("\n=== End of examples ===\n")
 
     session.close()
+
 
 if __name__ == "__main__":
     main()

--- a/src/eqlpy/eqlalchemy.py
+++ b/src/eqlpy/eqlalchemy.py
@@ -6,6 +6,7 @@ from functools import wraps
 from datetime import date
 import json
 
+
 class EqlTypeDecorator(TypeDecorator):
     def __init__(self, table, column):
         super().__init__()

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -1,7 +1,7 @@
 import json
 from django.db import models
 from datetime import datetime
-from django.db.models import Func, TextField
+from django.db.models import Func, TextField, Aggregate
 from django.db.models.fields import BooleanField
 
 
@@ -116,7 +116,7 @@ class CsSteVecTermV1(Func):
     def __init__(self, *expressions, **extra):
         super().__init__(*expressions, **extra)
 
-class CsGroupedValueV1(Func):
+class CsGroupedValueV1(Aggregate):
     function = 'cs_grouped_value_v1'
     output_field = TextField()
 

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -53,7 +53,6 @@ class EncryptedInt(EncryptedValue):
 
 
 class EncryptedBoolean(EncryptedValue):
-
     def _to_db_format(self, value):
         if value is None:
             return None
@@ -67,7 +66,6 @@ class EncryptedBoolean(EncryptedValue):
 
 
 class EncryptedDate(EncryptedValue):
-
     def _to_db_format(self, value):
         if value is None:
             return None

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -44,7 +44,7 @@ class EncryptedValue(models.JSONField):
         return self._from_db_format(value["p"])
 
     def db_type(self, connection):
-      return "cs_encrypted_v1"
+        return "cs_encrypted_v1"
 
 
 class EncryptedInt(EncryptedValue):
@@ -95,43 +95,52 @@ class EncryptedJsonb(EncryptedValue):
     def _from_db_format(self, value):
         return json.loads(value)
 
+
 # EQL functions
 
+
 class CsMatchV1(Func):
-    function = 'cs_match_v1'
+    function = "cs_match_v1"
     output_field = JSONField()
+
 
 class CsUniqueV1(Func):
-    function = 'cs_unique_v1'
+    function = "cs_unique_v1"
     output_field = JSONField()
+
 
 class CsOre648V1(Func):
-    function = 'cs_ore_64_8_v1'
+    function = "cs_ore_64_8_v1"
     output_field = JSONField()
+
 
 class CsSteVecV1(Func):
-    function = 'cs_ste_vec_v1'
+    function = "cs_ste_vec_v1"
     output_field = JSONField()
+
 
 class CsSteVecValueV1(Func):
-    function = 'cs_ste_vec_value_v1'
+    function = "cs_ste_vec_value_v1"
     output_field = JSONField()
 
+
 class CsSteVecTermV1(Func):
-    function = 'cs_ste_vec_term_v1'
+    function = "cs_ste_vec_term_v1"
     output_field = JSONField()
 
     def __init__(self, *expressions, **extra):
         super().__init__(*expressions, **extra)
 
+
 class CsGroupedValueV1(Aggregate):
-    function = 'cs_grouped_value_v1'
+    function = "cs_grouped_value_v1"
     output_field = JSONField()
+
 
 # meta-programming to create custom EQL operators for Django
 def create_operator(operator_name, template):
     class CsOperator(models.Func):
-        function = ''
+        function = ""
         output_field = BooleanField()
 
         def __init__(self, left, right, **extra):
@@ -143,7 +152,7 @@ def create_operator(operator_name, template):
             left_sql, left_params = compiler.compile(left)
             right_sql, right_params = compiler.compile(right)
 
-            template = self.template % {'left': left_sql, 'right': right_sql}
+            template = self.template % {"left": left_sql, "right": right_sql}
             params = left_params + right_params
 
             return template, params
@@ -152,8 +161,9 @@ def create_operator(operator_name, template):
 
     return CsOperator
 
-CsContains = create_operator('CsContains', '%(left)s @> %(right)s')
-CsContainedBy = create_operator('CsContainedBy', '%(left)s <@ %(right)s')
-CsEquals = create_operator('CsEquals', '%(left)s = %(right)s')
-CsGt = create_operator('CsGt', '%(left)s > %(right)s')
-CsLt = create_operator('CsLt', '%(left)s < %(right)s')
+
+CsContains = create_operator("CsContains", "%(left)s @> %(right)s")
+CsContainedBy = create_operator("CsContainedBy", "%(left)s <@ %(right)s")
+CsEquals = create_operator("CsEquals", "%(left)s = %(right)s")
+CsGt = create_operator("CsGt", "%(left)s > %(right)s")
+CsLt = create_operator("CsLt", "%(left)s < %(right)s")

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -1,11 +1,11 @@
 import json
 from django.db import models
 from datetime import datetime
-from django.db.models import Func, TextField, Aggregate
+from django.db.models import Func, JSONField, Aggregate
 from django.db.models.fields import BooleanField
 
 
-class EncryptedValue(models.TextField):
+class EncryptedValue(models.JSONField):
     def __init__(self, *args, **kwargs):
         self.table = kwargs.pop("table")
         self.column = kwargs.pop("column")
@@ -26,7 +26,7 @@ class EncryptedValue(models.TextField):
                 "v": 1,
                 "q": None,
             }
-            return json.dumps(dict)
+            return dict
         else:
             return None
 
@@ -38,7 +38,10 @@ class EncryptedValue(models.TextField):
     def from_db_value(self, value, expression, connection):
         if value is None:
             return None
-        return self._from_db_format(json.loads(value)["p"])
+        if isinstance(value, str):
+            # TODO: seems like we get a string from the database, but we should be getting a dict
+            value = json.loads(value)
+        return self._from_db_format(value["p"])
 
     def db_type(self, connection):
       return "cs_encrypted_v1"
@@ -96,34 +99,34 @@ class EncryptedJsonb(EncryptedValue):
 
 class CsMatchV1(Func):
     function = 'cs_match_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
 class CsUniqueV1(Func):
     function = 'cs_unique_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
 class CsOre648V1(Func):
     function = 'cs_ore_64_8_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
 class CsSteVecV1(Func):
     function = 'cs_ste_vec_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
 class CsSteVecValueV1(Func):
     function = 'cs_ste_vec_value_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
 class CsSteVecTermV1(Func):
     function = 'cs_ste_vec_term_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
     def __init__(self, *expressions, **extra):
         super().__init__(*expressions, **extra)
 
 class CsGroupedValueV1(Aggregate):
     function = 'cs_grouped_value_v1'
-    output_field = TextField()
+    output_field = JSONField()
 
 # meta-programming to create custom EQL operators for Django
 def create_operator(operator_name, template):

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -11,6 +11,12 @@ class EncryptedValue(models.TextField):
         self.column = kwargs.pop("column")
         super().__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs["table"] = self.table
+        kwargs["column"] = self.column
+        return name, path, args, kwargs
+
     def get_prep_value(self, value):
         if value is not None:
             dict = {

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -1,0 +1,90 @@
+import json
+from django.db import models
+from datetime import datetime
+
+
+class EqlValue(models.TextField):
+    def __init__(self, *args, **kwargs):
+        self.table = kwargs.pop("table")
+        self.column = kwargs.pop("column")
+        super().__init__(*args, **kwargs)
+
+    def pre_save(self, model_instance, add):
+        value = getattr(model_instance, self.attname)
+        if value is not None:
+            dict = {
+                "k": "pt",
+                "p": self._to_db_format(value),
+                "i": {"t": self.table, "c": self.column},
+                "v": 1,
+                "q": None,
+            }
+            return json.dumps(dict)
+        else:
+            return None
+
+    def _to_db_format(self, value):
+        if value is None:
+            return None
+        return str(value)
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return None
+        return self._from_db_format(json.loads(value)["p"])
+
+    def db_type(self, connection):
+      return "cs_encrypted_v1"
+
+
+class EqlInt(EqlValue):
+    def _from_db_format(self, value):
+        return int(value)
+
+
+class EqlBoolean(EqlValue):
+
+    def _to_db_format(self, value):
+        if value is None:
+            return None
+        elif value == True:
+            return "true"
+        else:
+            return "false"
+
+    def _from_db_format(self, value):
+        return value == "true"
+
+
+class EqlDate(EqlValue):
+
+    def _to_db_format(self, value):
+        if value is None:
+            return None
+
+        return value.isoformat()
+
+    def _from_db_format(self, value):
+        return datetime.fromisoformat(value).date()
+
+
+class EqlFloat(EqlValue):
+    def _from_db_format(self, value):
+        return float(value)
+
+
+class EqlUtf8Str(EqlValue):
+
+    def _from_db_format(self, value):
+        return value
+
+
+class EqlJsonb(EqlValue):
+    def _to_db_format(self, value):
+        if "foo" == "ejson_path":
+            return value
+        else:
+            return json.dumps(value)
+
+    def _from_db_format(self, value):
+        return json.loads(value)

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -11,8 +11,7 @@ class EncryptedValue(models.TextField):
         self.column = kwargs.pop("column")
         super().__init__(*args, **kwargs)
 
-    def pre_save(self, model_instance, add):
-        value = getattr(model_instance, self.attname)
+    def get_prep_value(self, value):
         if value is not None:
             dict = {
                 "k": "pt",

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -97,6 +97,7 @@ class EncryptedJsonb(EncryptedValue):
 
 
 # EQL functions
+# These classes are data structures that represent EQL functions
 
 
 class CsMatchV1(Func):
@@ -128,9 +129,6 @@ class CsSteVecTermV1(Func):
     function = "cs_ste_vec_term_v1"
     output_field = JSONField()
 
-    def __init__(self, *expressions, **extra):
-        super().__init__(*expressions, **extra)
-
 
 class CsGroupedValueV1(Aggregate):
     function = "cs_grouped_value_v1"
@@ -138,6 +136,9 @@ class CsGroupedValueV1(Aggregate):
 
 
 # meta-programming to create custom EQL operators for Django
+# This create_operator and the calls below define Classes
+# CsContains, CsContainedBy, CsEquals, CsGt, CsLt
+# which represent Postgres operators @>, <@, =, >, < respectively.
 def create_operator(operator_name, template):
     class CsOperator(models.Func):
         function = ""

--- a/tests/eqlpy/eqlalchemy_test.py
+++ b/tests/eqlpy/eqlalchemy_test.py
@@ -3,8 +3,6 @@ from datetime import date
 
 from eqlpy.eqlalchemy import *
 
-from pprint import pprint
-
 
 class EqlAlchemyTest(unittest.TestCase):
     def assert_common_parts(self, parsed):

--- a/tests/eqlpy/eqldjango_test.py
+++ b/tests/eqlpy/eqldjango_test.py
@@ -14,59 +14,52 @@ class EqlDjangoTest(unittest.TestCase):
     def test_encrypted_int(self):
         col_type = EncryptedInt(table="table", column="column")
         prep_value = col_type.get_prep_value(-2)
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
-        self.assertEqual("-2", parsed["p"])
+        self.assert_common_parts(prep_value)
+        self.assertEqual("-2", prep_value["p"])
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(-2, db_value)
 
     def test_encrypted_boolean_false(self):
         col_type = EncryptedBoolean(table="table", column="column")
         prep_value = col_type.get_prep_value(False)
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
-        self.assertEqual("false", parsed["p"])
+        self.assert_common_parts(prep_value)
+        self.assertEqual("false", prep_value["p"])
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(False, db_value)
 
     def test_encrypted_boolean_true(self):
         col_type = EncryptedBoolean(table="table", column="column")
         prep_value = col_type.get_prep_value(True)
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
-        self.assertEqual("true", parsed["p"])
+        self.assert_common_parts(prep_value)
+        self.assertEqual("true", prep_value["p"])
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(True, db_value)
 
     def test_encrypted_date(self):
         col_type = EncryptedDate(table="table", column="column")
         prep_value = col_type.get_prep_value(date(2024, 11, 17))
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
+        self.assert_common_parts(prep_value)
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(date(2024, 11, 17), db_value)
 
     def test_encrypted_float(self):
         col_type = EncryptedFloat(table="table", column="column")
         prep_value = col_type.get_prep_value(-0.01)
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
+        self.assert_common_parts(prep_value)
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(-0.01, db_value)
 
     def test_encrypted_text(self):
         col_type = EncryptedText(table="table", column="column")
         prep_value = col_type.get_prep_value("test string")
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
+        self.assert_common_parts(prep_value)
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual("test string", db_value)
 
     def test_encrypted_jsonb(self):
         col_type = EncryptedJsonb(table="table", column="column")
         prep_value = col_type.get_prep_value({"key": "value"})
-        parsed = json.loads(prep_value)
-        self.assert_common_parts(parsed)
+        self.assert_common_parts(prep_value)
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual({"key": "value"}, db_value)
 

--- a/tests/eqlpy/eqldjango_test.py
+++ b/tests/eqlpy/eqldjango_test.py
@@ -1,0 +1,85 @@
+import unittest
+import os
+from eqlpy.eqldjango import *
+from datetime import date
+
+
+class EqlDjangoTest(unittest.TestCase):
+    def assert_common_parts(self, parsed):
+        self.assertIsNone(parsed["q"])
+        self.assertEqual(parsed["i"]["t"], "table")
+        self.assertEqual(parsed["i"]["c"], "column")
+        self.assertEqual(parsed["v"], 1)
+
+    def test_encrypted_int(self):
+        col_type = EncryptedInt(table="table", column="column")
+        prep_value = col_type.get_prep_value(-2)
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        self.assertEqual("-2", parsed["p"])
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual(-2, db_value)
+
+    def test_encrypted_boolean_false(self):
+        col_type = EncryptedBoolean(table="table", column="column")
+        prep_value = col_type.get_prep_value(False)
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        self.assertEqual("false", parsed["p"])
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual(False, db_value)
+
+    def test_encrypted_boolean_true(self):
+        col_type = EncryptedBoolean(table="table", column="column")
+        prep_value = col_type.get_prep_value(True)
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        self.assertEqual("true", parsed["p"])
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual(True, db_value)
+
+    def test_encrypted_date(self):
+        col_type = EncryptedDate(table="table", column="column")
+        prep_value = col_type.get_prep_value(date(2024, 11, 17))
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual(date(2024, 11, 17), db_value)
+
+    def test_encrypted_float(self):
+        col_type = EncryptedFloat(table="table", column="column")
+        prep_value = col_type.get_prep_value(-0.01)
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual(-0.01, db_value)
+
+    def test_encrypted_text(self):
+        col_type = EncryptedText(table="table", column="column")
+        prep_value = col_type.get_prep_value("test string")
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual("test string", db_value)
+
+    def test_encrypted_jsonb(self):
+        col_type = EncryptedJsonb(table="table", column="column")
+        prep_value = col_type.get_prep_value({"key": "value"})
+        parsed = json.loads(prep_value)
+        self.assert_common_parts(parsed)
+        db_value = col_type.from_db_value(prep_value, None, None)
+        self.assertEqual({"key": "value"}, db_value)
+
+    def test_nones(self):
+        col_types = [
+            EncryptedInt,
+            EncryptedBoolean,
+            EncryptedDate,
+            EncryptedFloat,
+            EncryptedText,
+            EncryptedJsonb,
+        ]
+
+        for col_type in col_types:
+            prep_value = col_type(table="table", column="column").get_prep_value(None)
+            self.assertIsNone(prep_value)

--- a/tests/integration/eqlalchemy_integration_test.py
+++ b/tests/integration/eqlalchemy_integration_test.py
@@ -282,7 +282,6 @@ class TestExampleModel(unittest.TestCase):
             )
         )
         found = self.session.execute(query).all()
-        print(found)
         extracted = [EqlJsonb.from_parsed_json(row[0]) for row in found]
         self.assertEqual(sorted(extracted), [1, 2, 3])
 

--- a/tests/integration/eqlalchemy_integration_test.py
+++ b/tests/integration/eqlalchemy_integration_test.py
@@ -91,13 +91,6 @@ class TestExampleModel(unittest.TestCase):
             found.encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"}
         )
 
-    def test_example_prints_value(self):
-        self.example1.id = 1
-        self.assertEqual(
-            str(self.example1),
-            "<Example(id=1, encrypted_utf8_str=string123, encrypted_jsonb={'cat': 'a', 'key': ['value'], 'num': 1}, encrypted_int=1, encrypted_float=1.1, encrypted_date=2024-01-01, encrypted_boolean=True)>",
-        )
-
     # Simple update test for encrypted columns
     def test_update_encrypted_columns(self):
         example = (

--- a/tests/integration/eqlalchemy_integration_test.py
+++ b/tests/integration/eqlalchemy_integration_test.py
@@ -282,6 +282,7 @@ class TestExampleModel(unittest.TestCase):
             )
         )
         found = self.session.execute(query).all()
+        print(found)
         extracted = [EqlJsonb.from_parsed_json(row[0]) for row in found]
         self.assertEqual(sorted(extracted), [1, 2, 3])
 

--- a/tests/integration/eqlalchemy_integration_test.py
+++ b/tests/integration/eqlalchemy_integration_test.py
@@ -6,6 +6,7 @@ import os
 from eqlpy.eql_types import EqlFloat, EqlText, EqlJsonb
 from eqlpy.eqlalchemy import *
 
+
 class TestExampleModel(unittest.TestCase):
     pg_password = os.getenv("PGPASSWORD", "postgres")
     pg_user = os.getenv("PGUSER", "postgres")
@@ -47,7 +48,12 @@ class TestExampleModel(unittest.TestCase):
             True,
         )
         self.create_example_record(
-            -1, "another_example", {"num": 2, "cat": "b"}, 2.1, date(2024, 1, 2), False
+            -1,
+            '"another_example"',
+            {"num": 2, "cat": "b"},
+            2.1,
+            date(2024, 1, 2),
+            False,
         )
         self.create_example_record(
             0, "yet_another", {"num": 3, "cat": "b"}, 5.0, date(2024, 1, 3), False
@@ -58,7 +64,7 @@ class TestExampleModel(unittest.TestCase):
     def tearDown(self):
         self.session.rollback()
 
-    # Simple tests for storing and loading encrypteda columns
+    # Simple tests for storing and loading encrypted columns
     def test_encrypted_int(self):
         found = self.session.query(Example).filter(Example.id == self.example1.id).one()
         self.assertEqual(found.encrypted_int, 1)
@@ -174,7 +180,7 @@ class TestExampleModel(unittest.TestCase):
         )
         found = self.session.execute(query).scalar()
         self.assertEqual(2.1, found.encrypted_float)
-        self.assertEqual("another_example", found.encrypted_utf8_str)
+        self.assertEqual('"another_example"', found.encrypted_utf8_str)
 
     def test_float_ore(self):
         found = (

--- a/tests/integration/eqldjango_integration_test.py
+++ b/tests/integration/eqldjango_integration_test.py
@@ -1,0 +1,106 @@
+import unittest
+import os
+import django
+from django.conf import settings
+from django.db import models
+from eqlpy.eqldjango import *
+from datetime import date
+
+
+class TestSettings:
+    pg_password = os.getenv("PGPASSWORD", "postgres")
+    pg_user = os.getenv("PGUSER", "postgres")
+    pg_host = os.getenv("PGHOST", "localhost")
+    pg_port = os.getenv("PGPORT", "6432")
+    pg_db = os.getenv("PGDATABASE", "eqlpy_test")
+    secret_key = os.getenv("SECRET_KEY", "test_secret_key")
+
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        INSTALLED_APPS=[
+            "eql_django_integration_test",
+        ],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.postgresql",
+                "NAME": f"{TestSettings.pg_db}",
+                "USER": f"{TestSettings.pg_user}",
+                "PASSWORD": f"{TestSettings.pg_password}",
+                "HOST": f"{TestSettings.pg_host}",
+                "PORT": f"{TestSettings.pg_port}",
+            }
+        },
+        SECRET_KEY=f"{TestSettings.secret_key}",
+        AUTOCOMMIT=False,
+    )
+
+django.setup()
+
+
+class TestExampleDjangoModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def setUp(self):
+        Example.objects.all().delete()
+        self.example1 = Example(
+            encrypted_int=65535,
+            encrypted_boolean=True,
+            encrypted_utf8_str='test_string with \\ " "',
+            encrypted_date=date(2024, 1, 1),
+            encrypted_float=1.1,
+            encrypted_jsonb={"key": ["value"], "num": 1, "cat": "a"},
+        )
+        self.example1.save()
+
+    def test_save_null_example(self):
+        count = Example.objects.count()
+        self.null_eaxmple = Example()
+        self.null_eaxmple.save()
+        self.assertEqual(count + 1, Example.objects.count())
+
+    # Simple tests for storing and loading encrypted columns
+    def test_encrypted_int(self):
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(found.encrypted_int, 65535)
+
+    def test_encrypted_boolean(self):
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(found.encrypted_boolean, True)
+
+    def test_encrypted_date(self):
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(found.encrypted_date, date(2024, 1, 1))
+
+    def test_encrypted_float(self):
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(found.encrypted_float, 1.1)
+
+    def test_encrypted_utf8_str(self):
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(found.encrypted_utf8_str, 'test_string with \\ " "')
+
+    def test_encrypted_jsonb(self):
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(
+            found.encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"}
+        )
+
+
+class Example(models.Model):
+    encrypted_int = EqlInt(table="examples", column="encrypted_int", null=True)
+    encrypted_boolean = EqlBoolean(
+        table="examples", column="encrypted_boolean", null=True
+    )
+    encrypted_date = EqlDate(table="examples", column="encrypted_date", null=True)
+    encrypted_float = EqlFloat(table="examples", column="encrypted_float", null=True)
+    encrypted_utf8_str = EqlUtf8Str(
+        table="examples", column="encrypted_utf8_str", null=True
+    )
+    encrypted_jsonb = EqlJsonb(table="examples", column="encrypted_jsonb", null=True)
+
+    class Meta:
+        db_table = "examples"

--- a/tests/integration/eqldjango_integration_test.py
+++ b/tests/integration/eqldjango_integration_test.py
@@ -2,7 +2,10 @@ import unittest
 import os
 import django
 from django.conf import settings
-from django.db import models
+from django.db import models, connection
+from django.db.models import Q, F, Value, Count
+from django.db.models.expressions import RawSQL
+from eqlpy.eql_types import EqlFloat, EqlText, EqlJsonb
 from eqlpy.eqldjango import *
 from datetime import date
 
@@ -20,7 +23,7 @@ if not settings.configured:
     settings.configure(
         DEBUG=True,
         INSTALLED_APPS=[
-            "eql_django_integration_test",
+            "eqldjango_integration_test",
         ],
         DATABASES={
             "default": {
@@ -47,14 +50,34 @@ class TestExampleDjangoModel(unittest.TestCase):
     def setUp(self):
         Example.objects.all().delete()
         self.example1 = Example(
-            encrypted_int=65535,
+            encrypted_int=1,
             encrypted_boolean=True,
-            encrypted_utf8_str='test_string with \\ " "',
+            encrypted_utf8_str='string123',
             encrypted_date=date(2024, 1, 1),
             encrypted_float=1.1,
             encrypted_jsonb={"key": ["value"], "num": 1, "cat": "a"},
         )
         self.example1.save()
+
+        self.example2 = Example(
+            encrypted_int=-1,
+            encrypted_boolean=False,
+            encrypted_utf8_str='another_example',
+            encrypted_date=date(2024, 1, 2),
+            encrypted_float=2.1,
+            encrypted_jsonb={"num": 2, "cat": "b"},
+        )
+        self.example2.save()
+
+        self.example3 = Example(
+            encrypted_int=0,
+            encrypted_boolean=False,
+            encrypted_utf8_str='yet_another',
+            encrypted_date=date(2024, 1, 3),
+            encrypted_float=5.0,
+            encrypted_jsonb={"num": 3, "cat": "b"},
+        )
+        self.example3.save()
 
     def test_save_null_example(self):
         count = Example.objects.count()
@@ -65,7 +88,7 @@ class TestExampleDjangoModel(unittest.TestCase):
     # Simple tests for storing and loading encrypted columns
     def test_encrypted_int(self):
         found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_int, 65535)
+        self.assertEqual(found.encrypted_int, 1)
 
     def test_encrypted_boolean(self):
         found = Example.objects.get(id=self.example1.id)
@@ -81,7 +104,7 @@ class TestExampleDjangoModel(unittest.TestCase):
 
     def test_encrypted_utf8_str(self):
         found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_utf8_str, 'test_string with \\ " "')
+        self.assertEqual(found.encrypted_utf8_str, 'string123')
 
     def test_encrypted_jsonb(self):
         found = Example.objects.get(id=self.example1.id)
@@ -89,18 +112,233 @@ class TestExampleDjangoModel(unittest.TestCase):
             found.encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"}
         )
 
+    def test_update_encrypted_columns(self):
+        example = Example.objects.get(id=self.example1.id)
+        example.encrypted_float = 99.9
+        example.encrypted_utf8_str = "UPDATED_STRING"
+        example.encrypted_jsonb = { "UPDATED_KEY": "UPDATED VALUE" }
+        example.save()
+        found = Example.objects.get(id=self.example1.id)
+        self.assertEqual(found.encrypted_float, 99.9)
+        self.assertEqual(found.encrypted_utf8_str, "UPDATED_STRING")
+        self.assertEqual(found.encrypted_jsonb, { "UPDATED_KEY": "UPDATED VALUE" })
+
+    def test_string_partial_match_with_sql_clause(self):
+        term = EqlText("string", "examples", "encrypted_utf8_str").to_db_format("match")
+        result = Example.objects.raw(
+            "SELECT * FROM examples WHERE cs_match_v1(encrypted_utf8_str) @> cs_match_v1(%s)",
+            [term],
+        )[0]
+        self.assertEqual("string123", result.encrypted_utf8_str)
+
+    def test_string_partial_match(self):
+        term = EqlText("string", "examples", "encrypted_utf8_str").to_db_format("match")
+        query = Q(CsContains(
+            CsMatchV1(F('encrypted_utf8_str')),
+            CsMatchV1(Value(term))
+        ))
+        result = Example.objects.filter(query)
+        self.assertEqual(1, result.count())
+        self.assertEqual("string123", result[0].encrypted_utf8_str)
+
+    def test_string_exact_match_with_sql_clause(self):
+        term = EqlText("string123", "examples", "encrypted_utf8_str").to_db_format("unique")
+        result = Example.objects.raw(
+            "SELECT * FROM examples WHERE cs_unique_v1(encrypted_utf8_str) = cs_unique_v1(%s)",
+            [term],
+        )[0]
+        self.assertEqual("string123", result.encrypted_utf8_str)
+
+    def test_string_exact_match(self):
+        term = EqlText("string123", "examples", "encrypted_utf8_str").to_db_format("unique")
+        query = Q(
+            CsEquals(
+                CsUniqueV1(F('encrypted_utf8_str')), CsUniqueV1(Value(term))
+            )
+        )
+        found = Example.objects.get(query)
+        self.assertEqual(found.encrypted_utf8_str, "string123")
+
+    def test_float_ore_with_sql_clause(self):
+        term = EqlFloat(2.0, "examples", "encrypted_float").to_db_format("ore")
+        result = Example.objects.raw(
+            "SELECT * FROM examples WHERE cs_ore_64_8_v1(encrypted_float) > cs_ore_64_8_v1(%s)",
+            [term],
+        )
+        self.assertEqual(2.1, result[0].encrypted_float)
+        self.assertEqual(5.0, result[1].encrypted_float)
+
+    def test_float_ore(self):
+        term = EqlFloat(2.0, "examples", "encrypted_float").to_db_format("ore")
+        query = Q(
+            CsGt(
+                CsOre648V1(F('encrypted_float')), CsOre648V1(Value(term))
+            )
+        )
+        result = Example.objects.filter(query).all()
+        self.assertEqual(2.1, result[0].encrypted_float)
+        self.assertEqual(5.0, result[1].encrypted_float)
+
+    def test_jsonb_contains_with_sql_clause(self):
+        term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format("ste_vec")
+        result = Example.objects.raw(
+            "SELECT * FROM examples WHERE cs_ste_vec_v1(encrypted_jsonb) @> cs_ste_vec_v1(%s)",
+            [term],
+        )[0]
+        self.assertEqual(
+            {"key": ["value"], "num": 1, "cat": "a"}, result.encrypted_jsonb
+        )
+
+    def test_jsonb_contains(self):
+        term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format("ste_vec")
+        query = Q(
+            CsContains(
+                CsSteVecV1(F('encrypted_jsonb')), CsSteVecV1(Value(term))
+            )
+        )
+        found = Example.objects.get(query)
+        self.assertEqual(
+            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
+        )
+
+    def test_jsonb_contained_by_with_sql_clause(self):
+        term = EqlJsonb({"key": ["value", "another value"], "num": 1, "cat": "a", "non-existent": "val"}, "examples", "encrypted_jsonb").to_db_format("ste_vec")
+        result = Example.objects.raw(
+            "SELECT * FROM examples WHERE cs_ste_vec_v1(encrypted_jsonb) <@ cs_ste_vec_v1(%s)",
+            [term],
+        )[0]
+        self.assertEqual(
+            {"key": ["value"], "num": 1, "cat": "a"}, result.encrypted_jsonb
+        )
+
+    def test_jsonb_contained_by(self):
+        term = EqlJsonb({"key": ["value", "another value"], "num": 1, "cat": "a", "non-existent": "val"}, "examples", "encrypted_jsonb").to_db_format("ste_vec")
+        query = Q(
+            CsContainedBy(
+                CsSteVecV1(F('encrypted_jsonb')), CsSteVecV1(Value(term))
+            )
+        )
+        found = Example.objects.get(query)
+        self.assertEqual(
+            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
+        )
+
+    def test_jsonb_field_extraction_with_sql_clause(self):
+        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format("ejson_path")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT cs_ste_vec_value_v1(encrypted_jsonb, %s) AS extracted_value FROM examples",
+                [term],
+            )
+            results = cursor.fetchall()
+
+        extracted = [EqlJsonb.from_parsed_json(json.loads(row[0])) for row in results]
+        self.assertEqual(sorted(extracted), [1, 2, 3])
+
+    def test_jsonb_field_extraction(self):
+        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format("ejson_path")
+        results = Example.objects.annotate(
+            extracted_value = CsSteVecValueV1(F("encrypted_jsonb"), Value(term))
+        ).values_list('extracted_value', flat=True)
+
+        extracted = [EqlJsonb.from_parsed_json(json.loads(result)) for result in list(results)]
+
+    def test_jsonb_in_where_with_sql_clause(self):
+        term1=EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
+            "ejson_path"
+        ),
+        term2=EqlJsonb(2, "examples", "encrypted_jsonb").to_db_format(
+            "ste_vec"
+        ),
+        result = Example.objects.raw(
+            "SELECT * FROM examples WHERE cs_ste_vec_term_v1(encrypted_jsonb, %s) < cs_ste_vec_term_v1(%s)",
+            [term1, term2],
+        )[0]
+
+        self.assertEqual(
+            {"key": ["value"], "num": 1, "cat": "a"}, result.encrypted_jsonb
+        )
+
+    def test_jsonb_in_where(self):
+        term1=EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
+            "ejson_path"
+        ),
+        term2=EqlJsonb(2, "examples", "encrypted_jsonb").to_db_format(
+            "ste_vec"
+        ),
+        query = Q(
+            CsLt(
+                CsSteVecTermV1(F('encrypted_jsonb'), Value(term1)),
+                CsSteVecTermV1(Value(term2))
+            )
+        )
+        found = Example.objects.get(query)
+        self.assertEqual(
+            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
+        )
+
+
+    def test_jsonb_field_in_order_by_with_sql_clause(self):
+        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format("ejson_path")
+        results = Example.objects.raw(
+            "SELECT * FROM examples ORDER BY cs_ste_vec_term_v1(encrypted_jsonb, %s) DESC",
+            [term],
+        )
+        self.assertEqual(results[0].encrypted_jsonb, {"num": 3, "cat": "b"})
+        self.assertEqual(results[1].encrypted_jsonb, {"num": 2, "cat": "b"})
+        self.assertEqual(results[2].encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"})
+
+    def test_jsonb_field_in_order_by(self):
+        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format("ejson_path")
+        results = Example.objects.order_by(
+            CsSteVecTermV1(F("encrypted_jsonb"), Value(term)).desc()
+        )
+        self.assertEqual(results[0].encrypted_jsonb, {"num": 3, "cat": "b"})
+        self.assertEqual(results[1].encrypted_jsonb, {"num": 2, "cat": "b"})
+        self.assertEqual(results[2].encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"})
+
+    def test_jsonb_in_group_by_with_sql_clause(self):
+        term = EqlJsonb("$.cat", "examples", "encrypted_jsonb").to_db_format("ejson_path")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT cs_grouped_value_v1(cs_ste_vec_value_v1(encrypted_jsonb, %s)) AS category, COUNT(*) FROM examples GROUP BY cs_ste_vec_term_v1(encrypted_jsonb, %s)",
+                [term, term],
+            )
+            results = cursor.fetchall()
+
+        counts = [(EqlJsonb.from_parsed_json(json.loads(row[0])), row[1]) for row in results]
+        self.assertEqual(sorted(counts)[0], ("a", 1))
+        self.assertEqual(sorted(counts)[1], ("b", 2))
+
+    # TODO: This doesn't currently work
+    def test_jsonb_in_group_by(self):
+        term = EqlJsonb("$.cat", "examples", "encrypted_jsonb").to_db_format("ejson_path")
+        results = Example.objects.values(cat=CsSteVecTermV1(F("encrypted_jsonb"), Value(term))).annotate(
+            category=CsGroupedValueV1(CsSteVecValueV1(F("encrypted_jsonb"), Value(term))),
+            count=Count('*')
+        )
+
+        print(results)
+
+        result_list = list(results)
+        print(result_list)
+        self.assertEqual(EqlJsonb.from_parsed_json(result_list[0]['category']), "a")
+        self.assertEqual(result_list[0]['count'], 1)
+        self.assertEqual(EqlJsonb.from_parsed_json(result_list[1]['category']), "b")
+        self.assertEqual(result_list[1]['count'], 2)
+
 
 class Example(models.Model):
-    encrypted_int = EqlInt(table="examples", column="encrypted_int", null=True)
-    encrypted_boolean = EqlBoolean(
+    encrypted_int = EncryptedInt(table="examples", column="encrypted_int", null=True)
+    encrypted_boolean = EncryptedBoolean(
         table="examples", column="encrypted_boolean", null=True
     )
-    encrypted_date = EqlDate(table="examples", column="encrypted_date", null=True)
-    encrypted_float = EqlFloat(table="examples", column="encrypted_float", null=True)
-    encrypted_utf8_str = EqlUtf8Str(
+    encrypted_date = EncryptedDate(table="examples", column="encrypted_date", null=True)
+    encrypted_float = EncryptedFloat(table="examples", column="encrypted_float", null=True)
+    encrypted_utf8_str = EncryptedText(
         table="examples", column="encrypted_utf8_str", null=True
     )
-    encrypted_jsonb = EqlJsonb(table="examples", column="encrypted_jsonb", null=True)
+    encrypted_jsonb = EncryptedJsonb(table="examples", column="encrypted_jsonb", null=True)
 
     class Meta:
         db_table = "examples"

--- a/tests/integration/eqldjango_integration_test.py
+++ b/tests/integration/eqldjango_integration_test.py
@@ -262,10 +262,10 @@ class TestExampleDjangoModel(unittest.TestCase):
     def test_jsonb_in_where(self):
         term1=EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
             "ejson_path"
-        ),
+        )
         term2=EqlJsonb(2, "examples", "encrypted_jsonb").to_db_format(
             "ste_vec"
-        ),
+        )
         query = Q(
             CsLt(
                 CsSteVecTermV1(F('encrypted_jsonb'), Value(term1)),
@@ -310,7 +310,6 @@ class TestExampleDjangoModel(unittest.TestCase):
         self.assertEqual(sorted(counts)[0], ("a", 1))
         self.assertEqual(sorted(counts)[1], ("b", 2))
 
-    # TODO: This doesn't currently work
     def test_jsonb_in_group_by(self):
         term = EqlJsonb("$.cat", "examples", "encrypted_jsonb").to_db_format("ejson_path")
         results = Example.objects.values(cat=CsSteVecTermV1(F("encrypted_jsonb"), Value(term))).annotate(
@@ -318,13 +317,10 @@ class TestExampleDjangoModel(unittest.TestCase):
             count=Count('*')
         )
 
-        print(results)
-
         result_list = list(results)
-        print(result_list)
-        self.assertEqual(EqlJsonb.from_parsed_json(result_list[0]['category']), "a")
+        self.assertEqual(EqlJsonb.from_parsed_json(json.loads(result_list[0]['category'])), "a")
         self.assertEqual(result_list[0]['count'], 1)
-        self.assertEqual(EqlJsonb.from_parsed_json(result_list[1]['category']), "b")
+        self.assertEqual(EqlJsonb.from_parsed_json(json.loads(result_list[1]['category'])), "b")
         self.assertEqual(result_list[1]['count'], 2)
 
 

--- a/tests/integration/eqldjango_integration_test.py
+++ b/tests/integration/eqldjango_integration_test.py
@@ -241,7 +241,7 @@ class TestExampleDjangoModel(unittest.TestCase):
             extracted_value = CsSteVecValueV1(F("encrypted_jsonb"), Value(term))
         ).values_list('extracted_value', flat=True)
 
-        extracted = [EqlJsonb.from_parsed_json(json.loads(result)) for result in list(results)]
+        extracted = [EqlJsonb.from_parsed_json(result) for result in list(results)]
 
     def test_jsonb_in_where_with_sql_clause(self):
         term1=EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
@@ -318,11 +318,10 @@ class TestExampleDjangoModel(unittest.TestCase):
         )
 
         result_list = list(results)
-        self.assertEqual(EqlJsonb.from_parsed_json(json.loads(result_list[0]['category'])), "a")
+        self.assertEqual(EqlJsonb.from_parsed_json(result_list[0]['category']), "a")
         self.assertEqual(result_list[0]['count'], 1)
-        self.assertEqual(EqlJsonb.from_parsed_json(json.loads(result_list[1]['category'])), "b")
+        self.assertEqual(EqlJsonb.from_parsed_json(result_list[1]['category']), "b")
         self.assertEqual(result_list[1]['count'], 2)
-
 
 class Example(models.Model):
     encrypted_int = EncryptedInt(table="examples", column="encrypted_int", null=True)


### PR DESCRIPTION
This adds `eqldjango`, a module that implements Django ORM support for eql.

The features are equivalent to the sqlalchemy support via `eqlalchemy`. 