### PR TITLE
Enable integration tests with docker compose in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,24 +16,46 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PGPASSWORD: postgres
+      CS_WORKSPACE_ID: ${{ vars.CS_WORKSPACE_ID }}
+      CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+      CS_ENCRYPTION__CLIENT_ID: ${{ vars.CS_ENCRYPTION__CLIENT_ID }}
+      CS_ENCRYPTION__CLIENT_KEY: ${{ secrets.CS_ENCRYPTION__CLIENT_KEY }}
+      CS_DATASET_ID: ${{ vars.CS_DATASET_ID }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest sqlalchemy
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        # TODO: set up integration test environment and run integration tests as well
-        pytest tests/eqlpy/
+      - uses: actions/checkout@v4
+      - name: Start postgres
+        run: docker compose -f tests/integration/support/docker-compose.ci.yml up postgres -d
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest sqlalchemy psycopg2
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Istall postgres client
+        run: |
+           sudo apt-get update
+           sudo apt-get install -y postgresql-client
+      - name: Install EQL
+        run: curl -L https://github.com/cipherstash/encrypt-query-language/releases/download/eql-0.4.3/cipherstash-encrypt.sql | psql -h localhost -p 5432 -U postgres eqlpy_test
+      - name: Create appliaction types
+        run: psql -h localhost -p 5432 -U postgres eqlpy_test < tests/integration/support/application_types.sql
+      - name: Create test table
+        run: psql -h localhost -p 5432 -U postgres eqlpy_test < tests/integration/support/create_examples_table.sql
+      - name: Print dataset ID
+        run: echo ${CS_DATASET_ID}
+      - name: Start proxy
+        run: docker compose -f tests/integration/support/docker-compose.ci.yml up proxy -d
+      - name: Test with pytest
+        run: |
+          pytest tests/

--- a/tests/integration/eqlalchemy_integration_test.py
+++ b/tests/integration/eqlalchemy_integration_test.py
@@ -11,7 +11,7 @@ class TestExampleModel(unittest.TestCase):
     pg_user = os.getenv("PGUSER", "postgres")
     pg_host = os.getenv("PGHOST", "localhost")
     pg_port = os.getenv("PGPORT", "6432")
-    pg_db = os.getenv("PGDATABASE", "cipherstash_getting_started")
+    pg_db = os.getenv("PGDATABASE", "eqlpy_test")
 
     @classmethod
     def create_example_record(cls, id, utf8_str, jsonb, float_val, date_val, bool_val):

--- a/tests/integration/support/application_types.sql
+++ b/tests/integration/support/application_types.sql
@@ -1,0 +1,51 @@
+--
+-- Application-specific types
+--
+
+CREATE DOMAIN examples__encrypted_big_int AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_big_int'
+);
+
+CREATE DOMAIN examples__encrypted_boolean AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_boolean'
+);
+
+CREATE DOMAIN examples__encrypted_date AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_date'
+);
+
+CREATE DOMAIN examples__encrypted_float AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_float'
+);
+
+CREATE DOMAIN examples__encrypted_int AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_int'
+);
+
+CREATE DOMAIN examples__encrypted_small_int AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_small_int'
+);
+
+CREATE DOMAIN examples__encrypted_utf8_str AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_utf8_str'
+);
+
+CREATE DOMAIN examples__encrypted_jsonb AS cs_encrypted_v1
+CHECK(
+    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,c}' = 'encrypted_jsonb'
+);

--- a/tests/integration/support/create_examples_table.sql
+++ b/tests/integration/support/create_examples_table.sql
@@ -1,0 +1,34 @@
+create table examples (
+  id serial primary key,
+  encrypted_boolean examples__encrypted_boolean,
+  encrypted_date examples__encrypted_date,
+  encrypted_float examples__encrypted_float,
+  encrypted_int examples__encrypted_int,
+  encrypted_utf8_str examples__encrypted_utf8_str,
+  encrypted_jsonb examples__encrypted_jsonb
+);
+
+-- Add CipherStash indexes to Encrypt config
+SELECT cs_add_index_v1('examples', 'encrypted_boolean', 'ore', 'boolean');
+SELECT cs_add_index_v1('examples', 'encrypted_date', 'ore', 'date');
+SELECT cs_add_index_v1('examples', 'encrypted_float', 'ore', 'double');
+SELECT cs_add_index_v1('examples', 'encrypted_int', 'ore', 'int');
+SELECT cs_add_index_v1('examples', 'encrypted_utf8_str', 'unique', 'text', '{"token_filters": [{"kind": "downcase"}]}');
+SELECT cs_add_index_v1('examples', 'encrypted_utf8_str', 'match', 'text');
+SELECT cs_add_index_v1('examples', 'encrypted_utf8_str', 'ore', 'text');
+SELECT cs_add_index_v1('examples', 'encrypted_jsonb', 'ste_vec', 'jsonb', '{"prefix": "examples/encrypted_jsonb"}');
+
+-- Add corresponding PG indexes for each CipherStash index
+CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_boolean));
+CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_date));
+CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_float));
+CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_int));
+CREATE UNIQUE INDEX ON examples(cs_unique_v1(encrypted_utf8_str));
+CREATE INDEX ON examples USING GIN (cs_match_v1(encrypted_utf8_str));
+CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_utf8_str));
+-- CREATE INDEX ON examples USING GIN (cs_ste_vec_v1(encrypted_jsonb));
+
+-- Transition the Encrypt config state from "pending", to "encrypting", and then "active".
+-- The Encrypt config must be "active" for Proxy to use it.
+SELECT cs_encrypt_v1(true);
+SELECT cs_activate_v1();

--- a/tests/integration/support/docker-compose.ci.yml
+++ b/tests/integration/support/docker-compose.ci.yml
@@ -1,0 +1,40 @@
+services:
+  postgres:
+    container_name: eql_test_pg
+    image: postgres:16.2-bookworm
+    command: ["postgres", "-c", "log_statement=all"]
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: eqlpy_test
+    ports:
+      - ${PGPORT:-5432}:5432
+    networks:
+      - eql_test_nw
+  proxy:
+    container_name: eql_test_proxy
+    image: cipherstash/cipherstash-proxy:cipherstash-proxy-v0.3.4
+    depends_on:
+      - postgres
+    ports:
+      - ${CS_PORT:-6432}:${CS_PORT:-6432}
+    environment:
+      CS_WORKSPACE_ID: $CS_WORKSPACE_ID
+      CS_CLIENT_ACCESS_KEY: $CS_CLIENT_ACCESS_KEY
+      CS_ENCRYPTION__CLIENT_ID: $CS_ENCRYPTION__CLIENT_ID
+      CS_ENCRYPTION__CLIENT_KEY: $CS_ENCRYPTION__CLIENT_KEY
+      CS_ENCRYPTION__DATASET_ID: $CS_DATASET_ID
+      CS_TEST_ON_CHECKOUT: "true"
+      CS_AUDIT__ENABLED: "false"
+      CS_DATABASE__PORT: 5432
+      CS_DATABASE__USERNAME: postgres
+      CS_DATABASE__PASSWORD: postgres
+      CS_DATABASE__NAME: eqlpy_test
+      CS_DATABASE__HOST: eql_test_pg
+      CS_UNSAFE_LOGGING: "true"
+    networks:
+      - eql_test_nw
+
+networks:
+  eql_test_nw:
+    driver: bridge


### PR DESCRIPTION
This enables integration tests in CI with docker compose. Service containers would be nice but I spent a while and could not get them to communicate properly.

There is:

* no Python code change
* copy-paste of 'example' table creation SQL
* copy-paste of 'application data types' creation SQL
* docker-compose.ci.yml for CI
* updates of workflow to amke integration tests work

Possibly we should cache packages but currently the list is not huge, so I'm leaving it as is to get this working sooner.
We could come back later for caching.