### PR TITLE
New simpler query interface for Django

### DIFF
--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -105,7 +105,6 @@ class EncryptedUniqueEquals(Lookup):
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
         # TODO: could this be done in get_prep_value?
-        # this could also be 'ore'?
         rhs_params = [dict(e, q="unique") for e in rhs_params]
         params = map(json.dumps, (lhs_params + rhs_params))
         return "cs_unique_v1(%s) = cs_unique_v1(%s)" % (lhs, rhs), params
@@ -114,8 +113,26 @@ class EncryptedUniqueEquals(Lookup):
 EncryptedText.register_lookup(EncryptedUniqueEquals)
 
 
-class EncryptedTextContains(Lookup):
-    lookup_name = "contains"
+class EncryptedOreEquals(Lookup):
+    lookup_name = "eq"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # TODO: could this be done in get_prep_value?
+        rhs_params = [dict(e, q="ore") for e in rhs_params]
+        params = map(json.dumps, (lhs_params + rhs_params))
+        return "cs_ore_64_8_v1(%s) = cs_ore_64_8_v1(%s)" % (lhs, rhs), params
+
+
+EncryptedBoolean.register_lookup(EncryptedOreEquals)
+EncryptedDate.register_lookup(EncryptedOreEquals)
+EncryptedInt.register_lookup(EncryptedOreEquals)
+EncryptedFloat.register_lookup(EncryptedOreEquals)
+
+
+class EncryptedTextMatch(Lookup):
+    lookup_name = "match"
 
     def as_sql(self, compiler, connection):
         lhs, lhs_params = self.process_lhs(compiler, connection)
@@ -126,7 +143,7 @@ class EncryptedTextContains(Lookup):
         return "cs_match_v1(%s) @> cs_match_v1(%s)" % (lhs, rhs), params
 
 
-EncryptedText.register_lookup(EncryptedTextContains)
+EncryptedText.register_lookup(EncryptedTextMatch)
 
 
 class EncryptedOreLt(Lookup):
@@ -143,6 +160,7 @@ class EncryptedOreLt(Lookup):
 
 EncryptedFloat.register_lookup(EncryptedOreLt)
 EncryptedInt.register_lookup(EncryptedOreLt)
+EncryptedDate.register_lookup(EncryptedOreLt)
 
 
 class EncryptedOreGt(Lookup):
@@ -159,6 +177,7 @@ class EncryptedOreGt(Lookup):
 
 EncryptedFloat.register_lookup(EncryptedOreGt)
 EncryptedInt.register_lookup(EncryptedOreGt)
+EncryptedDate.register_lookup(EncryptedOreGt)
 
 
 class EncryptedJsonContains(Lookup):
@@ -244,6 +263,7 @@ def create_operator(operator_name, template):
 
 
 CsContains = create_operator("CsContains", "%(left)s @> %(right)s")
+CsMatch = create_operator("CsMatch", "%(left)s @> %(right)s")
 CsContainedBy = create_operator("CsContainedBy", "%(left)s <@ %(right)s")
 CsEquals = create_operator("CsEquals", "%(left)s = %(right)s")
 CsGt = create_operator("CsGt", "%(left)s > %(right)s")

--- a/src/eqlpy/eqldjango.py
+++ b/src/eqlpy/eqldjango.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.db.models import Func, JSONField, Aggregate
 from django.db.models.fields import BooleanField
 from django.db.models import Q, F, Value
+from django.db.models.lookups import Lookup
 from eqlpy.eql_types import EqlFloat, EqlText, EqlJsonb
 from functools import reduce
 
@@ -97,45 +98,86 @@ class EncryptedJsonb(EncryptedValue):
         return json.loads(value)
 
 
-# Experimental query interface
-class Unchained(object):
-    def __init__(self, table):
-        self.table = table
+class EncryptedUniqueEquals(Lookup):
+    lookup_name = "eq"
 
-    def __call__(self, **kwargs):
-        query_exps = []
-        for key, value in kwargs.items():
-            # if splittable by __, then get col, op from key, val from value
-            if "__" in key:
-                col, op = key.split("__", maxsplit=1)
-                if op == "s_contains":
-                    term = EqlText(value, self.table, col).to_db_format("match")
-                    query = Q(CsContains(CsMatchV1(F(col)), CsMatchV1(Value(term))))
-                    query_exps.append(query)
-                elif op == "j_contains":
-                    term = EqlJsonb(value, self.table, col).to_db_format("ste_vec")
-                    query = Q(CsContains(CsSteVecV1(F(col)), CsSteVecV1(Value(term))))
-                    query_exps.append(query)
-                elif op == "gt":
-                    term = EqlFloat(value, self.table, col).to_db_format("ore")
-                    query = Q(CsGt(CsOre648V1(F(col)), CsOre648V1(Value(term))))
-                    query_exps.append(query)
-                elif op == "lt":
-                    term = EqlFloat(value, self.table, col).to_db_format("ore")
-                    query = Q(CsLt(CsOre648V1(F(col)), CsOre648V1(Value(term))))
-                    query_exps.append(query)
-                else:
-                    raise ValueError(f"Unsupported operator: {op}")
-            else:
-                # key does not contain __ (eg. age__gt ), so it's exact match
-                term = EqlText(value, self.table, key).to_db_format("unique")
-                query = Q(CsEquals(CsUniqueV1(F(key)), CsUniqueV1(Value(term))))
-                query_exps.append(query)
-        return reduce(lambda x, y: x & y, query_exps)
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # TODO: could this be done in get_prep_value?
+        # this could also be 'ore'?
+        rhs_params = [dict(e, q="unique") for e in rhs_params]
+        params = map(json.dumps, (lhs_params + rhs_params))
+        return "cs_unique_v1(%s) = cs_unique_v1(%s)" % (lhs, rhs), params
 
+
+EncryptedText.register_lookup(EncryptedUniqueEquals)
+
+
+class EncryptedTextContains(Lookup):
+    lookup_name = "contains"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # TODO: could this be done in get_prep_value?
+        rhs_params = [dict(e, q="match") for e in rhs_params]
+        params = map(json.dumps, (lhs_params + rhs_params))
+        return "cs_match_v1(%s) @> cs_match_v1(%s)" % (lhs, rhs), params
+
+
+EncryptedText.register_lookup(EncryptedTextContains)
+
+
+class EncryptedOreLt(Lookup):
+    lookup_name = "lt"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # TODO: could this be done in get_prep_value?
+        rhs_params = [dict(e, q="ore") for e in rhs_params]
+        params = map(json.dumps, (lhs_params + rhs_params))
+        return "cs_ore_64_8_v1(%s) < cs_ore_64_8_v1(%s)" % (lhs, rhs), params
+
+
+EncryptedFloat.register_lookup(EncryptedOreLt)
+EncryptedInt.register_lookup(EncryptedOreLt)
+
+
+class EncryptedOreGt(Lookup):
+    lookup_name = "gt"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # TODO: could this be done in get_prep_value?
+        rhs_params = [dict(e, q="ore") for e in rhs_params]
+        params = map(json.dumps, (lhs_params + rhs_params))
+        return "cs_ore_64_8_v1(%s) > cs_ore_64_8_v1(%s)" % (lhs, rhs), params
+
+
+EncryptedFloat.register_lookup(EncryptedOreGt)
+EncryptedInt.register_lookup(EncryptedOreGt)
+
+
+class EncryptedJsonContains(Lookup):
+    lookup_name = "contains"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        # TODO: could this be done in get_prep_value?
+        rhs_params = [dict(e, q="ste_vec") for e in rhs_params]
+        params = map(json.dumps, (lhs_params + rhs_params))
+        return "cs_ste_vec_v1(%s) @> cs_ste_vec_v1(%s)" % (lhs, rhs), params
+
+
+EncryptedJsonb.register_lookup(EncryptedJsonContains)
 
 # EQL functions
 # These classes are data structures that represent EQL functions
+# Needed for complex EQL queries
 
 
 class CsMatchV1(Func):

--- a/tests/eqlpy/eql_types_test.py
+++ b/tests/eqlpy/eql_types_test.py
@@ -104,33 +104,27 @@ class EqlTest(unittest.TestCase):
 
     def test_eql_row_makes_row(self):
         column_function_mapping = {
-            "encrypted_int": EqlInt.from_parsed_json,
-            "encrypted_boolean": EqlBool.from_parsed_json,
-            "encrypted_date": EqlDate.from_parsed_json,
-            "encrypted_float": EqlFloat.from_parsed_json,
-            "encrypted_utf8_str": EqlText.from_parsed_json,
-            "encrypted_jsonb": EqlText.from_parsed_json,
+            "age": EqlInt.from_parsed_json,
+            "is_citizen": EqlBool.from_parsed_json,
+            "start_date": EqlDate.from_parsed_json,
+            "weight": EqlFloat.from_parsed_json,
+            "name": EqlText.from_parsed_json,
+            "extra_info": EqlText.from_parsed_json,
         }
 
         eql_row = EqlRow(
             column_function_mapping,
             {
-                "encrypted_int": json.loads(
-                    EqlInt(1, "table", "column").to_db_format()
-                ),
-                "encrypted_boolean": json.loads(
+                "age": json.loads(EqlInt(1, "table", "column").to_db_format()),
+                "is_citizen": json.loads(
                     EqlBool(True, "table", "column").to_db_format()
                 ),
-                "encrypted_date": json.loads(
+                "start_date": json.loads(
                     EqlDate(date(2024, 11, 1), "table", "column").to_db_format()
                 ),
-                "encrypted_float": json.loads(
-                    EqlFloat(1.1, "table", "column").to_db_format()
-                ),
-                "encrypted_utf8_str": json.loads(
-                    EqlText("text", "table", "column").to_db_format()
-                ),
-                "encrypted_jsonb": json.loads(
+                "weight": json.loads(EqlFloat(1.1, "table", "column").to_db_format()),
+                "name": json.loads(EqlText("text", "table", "column").to_db_format()),
+                "extra_info": json.loads(
                     EqlJsonb('{"a": 1}', "table", "column").to_db_format()
                 ),
             },
@@ -139,12 +133,12 @@ class EqlTest(unittest.TestCase):
         self.assertEqual(
             eql_row.row,
             {
-                "encrypted_int": 1,
-                "encrypted_boolean": True,
-                "encrypted_date": date(2024, 11, 1),
-                "encrypted_float": 1.1,
-                "encrypted_utf8_str": "text",
-                "encrypted_jsonb": '"{\\"a\\": 1}"',
+                "age": 1,
+                "is_citizen": True,
+                "start_date": date(2024, 11, 1),
+                "weight": 1.1,
+                "name": "text",
+                "extra_info": '"{\\"a\\": 1}"',
             },
         )
 

--- a/tests/eqlpy/eqlalchemy_test.py
+++ b/tests/eqlpy/eqlalchemy_test.py
@@ -11,7 +11,7 @@ class EqlAlchemyTest(unittest.TestCase):
         self.assertEqual(parsed["i"]["c"], "column")
         self.assertEqual(parsed["v"], 1)
 
-    def test_encrypted_int(self):
+    def test_age(self):
         col_type = EncryptedInt("table", "column")
         bound = col_type.process_bind_param(-2, None)
         parsed = json.loads(bound)
@@ -21,7 +21,7 @@ class EqlAlchemyTest(unittest.TestCase):
         result = col_type.process_result_value(parsed, None)
         self.assertEqual(result, -2)
 
-    def test_encrypted_boolean_false(self):
+    def test_is_citizen_false(self):
         col_type = EncryptedBoolean("table", "column")
         bound = col_type.process_bind_param(False, None)
         parsed = json.loads(bound)
@@ -31,7 +31,7 @@ class EqlAlchemyTest(unittest.TestCase):
         result = col_type.process_result_value(parsed, None)
         self.assertEqual(result, False)
 
-    def test_encrypted_boolean_true(self):
+    def test_is_citizen_true(self):
         col_type = EncryptedBoolean("table", "column")
         bound = col_type.process_bind_param(True, None)
         parsed = json.loads(bound)
@@ -41,7 +41,7 @@ class EqlAlchemyTest(unittest.TestCase):
         result = col_type.process_result_value(parsed, None)
         self.assertEqual(result, True)
 
-    def test_encrypted_date(self):
+    def test_start_date(self):
         col_type = EncryptedDate("table", "column")
         bound = col_type.process_bind_param(date(2024, 11, 17), None)
         parsed = json.loads(bound)
@@ -51,7 +51,7 @@ class EqlAlchemyTest(unittest.TestCase):
         result = col_type.process_result_value(parsed, None)
         self.assertEqual(result, date(2024, 11, 17))
 
-    def test_encrypted_float(self):
+    def test_weight(self):
         col_type = EncryptedFloat("table", "column")
         bound = col_type.process_bind_param(-0.01, None)
         parsed = json.loads(bound)
@@ -61,7 +61,7 @@ class EqlAlchemyTest(unittest.TestCase):
         result = col_type.process_result_value(parsed, None)
         self.assertEqual(result, -0.01)
 
-    def test_encrypted_utf8_str(self):
+    def test_name(self):
         col_type = EncryptedUtf8Str("table", "column")
         bound = col_type.process_bind_param("test string", None)
         parsed = json.loads(bound)
@@ -71,7 +71,7 @@ class EqlAlchemyTest(unittest.TestCase):
         result = col_type.process_result_value(parsed, None)
         self.assertEqual(result, "test string")
 
-    def test_encrypted_jsonb(self):
+    def test_extra_info(self):
         col_type = EncryptedJsonb("table", "column")
         bound = col_type.process_bind_param({"key": "value"}, None)
         parsed = json.loads(bound)

--- a/tests/eqlpy/eqldjango_test.py
+++ b/tests/eqlpy/eqldjango_test.py
@@ -11,7 +11,7 @@ class EqlDjangoTest(unittest.TestCase):
         self.assertEqual(parsed["i"]["c"], "column")
         self.assertEqual(parsed["v"], 1)
 
-    def test_encrypted_int(self):
+    def test_age(self):
         col_type = EncryptedInt(table="table", column="column")
         prep_value = col_type.get_prep_value(-2)
         self.assert_common_parts(prep_value)
@@ -19,7 +19,7 @@ class EqlDjangoTest(unittest.TestCase):
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(-2, db_value)
 
-    def test_encrypted_boolean_false(self):
+    def test_is_citizen_false(self):
         col_type = EncryptedBoolean(table="table", column="column")
         prep_value = col_type.get_prep_value(False)
         self.assert_common_parts(prep_value)
@@ -27,7 +27,7 @@ class EqlDjangoTest(unittest.TestCase):
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(False, db_value)
 
-    def test_encrypted_boolean_true(self):
+    def test_is_citizen_true(self):
         col_type = EncryptedBoolean(table="table", column="column")
         prep_value = col_type.get_prep_value(True)
         self.assert_common_parts(prep_value)
@@ -35,14 +35,14 @@ class EqlDjangoTest(unittest.TestCase):
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(True, db_value)
 
-    def test_encrypted_date(self):
+    def test_start_date(self):
         col_type = EncryptedDate(table="table", column="column")
         prep_value = col_type.get_prep_value(date(2024, 11, 17))
         self.assert_common_parts(prep_value)
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual(date(2024, 11, 17), db_value)
 
-    def test_encrypted_float(self):
+    def test_weight(self):
         col_type = EncryptedFloat(table="table", column="column")
         prep_value = col_type.get_prep_value(-0.01)
         self.assert_common_parts(prep_value)
@@ -56,7 +56,7 @@ class EqlDjangoTest(unittest.TestCase):
         db_value = col_type.from_db_value(prep_value, None, None)
         self.assertEqual("test string", db_value)
 
-    def test_encrypted_jsonb(self):
+    def test_extra_info(self):
         col_type = EncryptedJsonb(table="table", column="column")
         prep_value = col_type.get_prep_value({"key": "value"})
         self.assert_common_parts(prep_value)

--- a/tests/integration/eqldjango_integration_test.py
+++ b/tests/integration/eqldjango_integration_test.py
@@ -3,7 +3,7 @@ import os
 import django
 from django.conf import settings
 from django.db import models, connection
-from django.db.models import Q, F, Value, Count
+from django.db.models import Q, F, Value, Count, IntegerField
 from django.db.models.expressions import RawSQL
 from eqlpy.eql_types import EqlFloat, EqlText, EqlJsonb
 from eqlpy.eqldjango import *
@@ -42,167 +42,152 @@ if not settings.configured:
 django.setup()
 
 
-def create_example_records():
-    example1 = Example(
-        encrypted_int=1,
-        encrypted_boolean=True,
-        encrypted_utf8_str="string123",
-        encrypted_date=date(2024, 1, 1),
-        encrypted_float=1.1,
-        encrypted_jsonb={"key": ["value"], "num": 1, "cat": "a"},
+def create_customer_records():
+    customer1 = Customer(
+        age=31,
+        is_citizen=True,
+        name="Alice Developer",
+        start_date=date(2024, 1, 1),
+        weight=51.1,
+        extra_info={"key": ["value"], "num": 1, "cat": "a"},
+        visit_count=0,
     )
-    example1.save()
+    customer1.save()
 
-    example2 = Example(
-        encrypted_int=-1,
-        encrypted_boolean=False,
-        encrypted_utf8_str="another_example",
-        encrypted_date=date(2024, 1, 2),
-        encrypted_float=2.1,
-        encrypted_jsonb={"num": 2, "cat": "b"},
+    customer2 = Customer(
+        age=29,
+        is_citizen=False,
+        name="Bob Customer",
+        start_date=date(2024, 1, 2),
+        weight=82.1,
+        extra_info={"num": 2, "cat": "b"},
+        visit_count=1,
     )
-    example2.save()
+    customer2.save()
 
-    example3 = Example(
-        encrypted_int=0,
-        encrypted_boolean=False,
-        encrypted_utf8_str="yet_another",
-        encrypted_date=date(2024, 1, 3),
-        encrypted_float=5.0,
-        encrypted_jsonb={"num": 3, "cat": "b"},
+    customer3 = Customer(
+        age=30,
+        is_citizen=False,
+        name="Carol Customer",
+        start_date=date(2024, 1, 3),
+        weight=55.0,
+        extra_info={"num": 3, "cat": "b"},
+        visit_count=2,
     )
-    example3.save()
+    customer3.save()
 
-    return [example1, example2, example3]
+    return [customer1, customer2, customer3]
 
 
-class TestExampleDjangoModel(unittest.TestCase):
+class TestCustomerDjangoModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         pass
 
     def setUp(self):
-        Example.objects.all().delete()
-        self.example1, self.example2, self.example3 = create_example_records()
+        Customer.objects.all().delete()
+        self.customer1, self.customer2, self.customer3 = create_customer_records()
 
-    def test_save_null_example(self):
-        count = Example.objects.count()
-        self.null_eaxmple = Example()
+    def test_save_null_customer(self):
+        count = Customer.objects.count()
+        self.null_eaxmple = Customer()
         self.null_eaxmple.save()
-        self.assertEqual(count + 1, Example.objects.count())
+        self.assertEqual(count + 1, Customer.objects.count())
 
     # Simple tests for storing and loading encrypted columns
-    def test_encrypted_int(self):
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_int, 1)
+    def test_age(self):
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.age, 31)
 
-    def test_encrypted_boolean(self):
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_boolean, True)
+    def test_is_citizen(self):
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.is_citizen, True)
 
-    def test_encrypted_date(self):
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_date, date(2024, 1, 1))
+    def test_start_date(self):
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.start_date, date(2024, 1, 1))
 
-    def test_encrypted_float(self):
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_float, 1.1)
+    def test_weight(self):
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.weight, 51.1)
 
-    def test_encrypted_utf8_str(self):
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_utf8_str, "string123")
+    def test_name(self):
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.name, "Alice Developer")
 
-    def test_encrypted_jsonb(self):
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(
-            found.encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"}
-        )
+    def test_extra_info(self):
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.extra_info, {"key": ["value"], "num": 1, "cat": "a"})
 
     def test_update_encrypted_columns(self):
-        example = Example.objects.get(id=self.example1.id)
-        example.encrypted_float = 99.9
-        example.encrypted_utf8_str = "UPDATED_STRING"
-        example.encrypted_jsonb = {"UPDATED_KEY": "UPDATED VALUE"}
-        example.save()
-        found = Example.objects.get(id=self.example1.id)
-        self.assertEqual(found.encrypted_float, 99.9)
-        self.assertEqual(found.encrypted_utf8_str, "UPDATED_STRING")
-        self.assertEqual(found.encrypted_jsonb, {"UPDATED_KEY": "UPDATED VALUE"})
+        customer = Customer.objects.get(id=self.customer1.id)
+        customer.weight = 99.9
+        customer.name = "UPDATED_STRING"
+        customer.extra_info = {"UPDATED_KEY": "UPDATED VALUE"}
+        customer.save()
+        found = Customer.objects.get(id=self.customer1.id)
+        self.assertEqual(found.weight, 99.9)
+        self.assertEqual(found.name, "UPDATED_STRING")
+        self.assertEqual(found.extra_info, {"UPDATED_KEY": "UPDATED VALUE"})
 
     def test_string_partial_match_with_sql_clause(self):
-        term = EqlText("string", "examples", "encrypted_utf8_str").to_db_format("match")
-        result = Example.objects.raw(
-            "SELECT * FROM examples WHERE cs_match_v1(encrypted_utf8_str) @> cs_match_v1(%s)",
+        term = EqlText("ali", "customers", "name").to_db_format("match")
+        result = Customer.objects.raw(
+            "SELECT * FROM customers WHERE cs_match_v1(name) @> cs_match_v1(%s)",
             [term],
         )[0]
-        self.assertEqual("string123", result.encrypted_utf8_str)
+        self.assertEqual("Alice Developer", result.name)
 
     def test_string_partial_match(self):
-        term = EqlText("string", "examples", "encrypted_utf8_str").to_db_format("match")
-        query = Q(
-            CsContains(CsMatchV1(F("encrypted_utf8_str")), CsMatchV1(Value(term)))
-        )
-        result = Example.objects.filter(query)
+        term = EqlText("ali", "customers", "name").to_db_format("match")
+        query = Q(CsContains(CsMatchV1(F("name")), CsMatchV1(Value(term))))
+        result = Customer.objects.filter(query)
         self.assertEqual(1, result.count())
-        self.assertEqual("string123", result[0].encrypted_utf8_str)
+        self.assertEqual("Alice Developer", result[0].name)
 
     def test_string_exact_match_with_sql_clause(self):
-        term = EqlText("string123", "examples", "encrypted_utf8_str").to_db_format(
-            "unique"
-        )
-        result = Example.objects.raw(
-            "SELECT * FROM examples WHERE cs_unique_v1(encrypted_utf8_str) = cs_unique_v1(%s)",
+        term = EqlText("Alice Developer", "customers", "name").to_db_format("unique")
+        result = Customer.objects.raw(
+            "SELECT * FROM customers WHERE cs_unique_v1(name) = cs_unique_v1(%s)",
             [term],
         )[0]
-        self.assertEqual("string123", result.encrypted_utf8_str)
+        self.assertEqual("Alice Developer", result.name)
 
     def test_string_exact_match(self):
-        term = EqlText("string123", "examples", "encrypted_utf8_str").to_db_format(
-            "unique"
-        )
-        query = Q(
-            CsEquals(CsUniqueV1(F("encrypted_utf8_str")), CsUniqueV1(Value(term)))
-        )
-        found = Example.objects.get(query)
-        self.assertEqual(found.encrypted_utf8_str, "string123")
+        term = EqlText("Alice Developer", "customers", "name").to_db_format("unique")
+        query = Q(CsEquals(CsUniqueV1(F("name")), CsUniqueV1(Value(term))))
+        found = Customer.objects.get(query)
+        self.assertEqual(found.name, "Alice Developer")
 
     def test_float_ore_with_sql_clause(self):
-        term = EqlFloat(2.0, "examples", "encrypted_float").to_db_format("ore")
-        result = Example.objects.raw(
-            "SELECT * FROM examples WHERE cs_ore_64_8_v1(encrypted_float) > cs_ore_64_8_v1(%s)",
+        term = EqlFloat(80.0, "customers", "weight").to_db_format("ore")
+        result = Customer.objects.raw(
+            "SELECT * FROM customers WHERE cs_ore_64_8_v1(weight) < cs_ore_64_8_v1(%s)",
             [term],
         )
-        self.assertEqual(2.1, result[0].encrypted_float)
-        self.assertEqual(5.0, result[1].encrypted_float)
+        self.assertEqual(51.1, result[0].weight)
+        self.assertEqual(55.0, result[1].weight)
 
     def test_float_ore(self):
-        term = EqlFloat(2.0, "examples", "encrypted_float").to_db_format("ore")
-        query = Q(CsGt(CsOre648V1(F("encrypted_float")), CsOre648V1(Value(term))))
-        result = Example.objects.filter(query).all()
-        self.assertEqual(2.1, result[0].encrypted_float)
-        self.assertEqual(5.0, result[1].encrypted_float)
+        term = EqlFloat(80.0, "customers", "weight").to_db_format("ore")
+        query = Q(CsLt(CsOre648V1(F("weight")), CsOre648V1(Value(term))))
+        result = Customer.objects.filter(query).all()
+        self.assertEqual(51.1, result[0].weight)
+        self.assertEqual(55.0, result[1].weight)
 
     def test_jsonb_contains_with_sql_clause(self):
-        term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format(
-            "ste_vec"
-        )
-        result = Example.objects.raw(
-            "SELECT * FROM examples WHERE cs_ste_vec_v1(encrypted_jsonb) @> cs_ste_vec_v1(%s)",
+        term = EqlJsonb({"key": []}, "customers", "extra_info").to_db_format("ste_vec")
+        result = Customer.objects.raw(
+            "SELECT * FROM customers WHERE cs_ste_vec_v1(extra_info) @> cs_ste_vec_v1(%s)",
             [term],
         )[0]
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, result.encrypted_jsonb
-        )
+        self.assertEqual({"key": ["value"], "num": 1, "cat": "a"}, result.extra_info)
 
     def test_jsonb_contains(self):
-        term = EqlJsonb({"key": []}, "examples", "encrypted_jsonb").to_db_format(
-            "ste_vec"
-        )
-        query = Q(CsContains(CsSteVecV1(F("encrypted_jsonb")), CsSteVecV1(Value(term))))
-        found = Example.objects.get(query)
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
-        )
+        term = EqlJsonb({"key": []}, "customers", "extra_info").to_db_format("ste_vec")
+        query = Q(CsContains(CsSteVecV1(F("extra_info")), CsSteVecV1(Value(term))))
+        found = Customer.objects.get(query)
+        self.assertEqual({"key": ["value"], "num": 1, "cat": "a"}, found.extra_info)
 
     def test_jsonb_contained_by_with_sql_clause(self):
         term = EqlJsonb(
@@ -212,16 +197,14 @@ class TestExampleDjangoModel(unittest.TestCase):
                 "cat": "a",
                 "non-existent": "val",
             },
-            "examples",
-            "encrypted_jsonb",
+            "customers",
+            "extra_info",
         ).to_db_format("ste_vec")
-        result = Example.objects.raw(
-            "SELECT * FROM examples WHERE cs_ste_vec_v1(encrypted_jsonb) <@ cs_ste_vec_v1(%s)",
+        result = Customer.objects.raw(
+            "SELECT * FROM customers WHERE cs_ste_vec_v1(extra_info) <@ cs_ste_vec_v1(%s)",
             [term],
         )[0]
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, result.encrypted_jsonb
-        )
+        self.assertEqual({"key": ["value"], "num": 1, "cat": "a"}, result.extra_info)
 
     def test_jsonb_contained_by(self):
         term = EqlJsonb(
@@ -231,24 +214,18 @@ class TestExampleDjangoModel(unittest.TestCase):
                 "cat": "a",
                 "non-existent": "val",
             },
-            "examples",
-            "encrypted_jsonb",
+            "customers",
+            "extra_info",
         ).to_db_format("ste_vec")
-        query = Q(
-            CsContainedBy(CsSteVecV1(F("encrypted_jsonb")), CsSteVecV1(Value(term)))
-        )
-        found = Example.objects.get(query)
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
-        )
+        query = Q(CsContainedBy(CsSteVecV1(F("extra_info")), CsSteVecV1(Value(term))))
+        found = Customer.objects.get(query)
+        self.assertEqual({"key": ["value"], "num": 1, "cat": "a"}, found.extra_info)
 
     def test_jsonb_field_extraction_with_sql_clause(self):
-        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
-        )
+        term = EqlJsonb("$.num", "customers", "extra_info").to_db_format("ejson_path")
         with connection.cursor() as cursor:
             cursor.execute(
-                "SELECT cs_ste_vec_value_v1(encrypted_jsonb, %s) AS extracted_value FROM examples",
+                "SELECT cs_ste_vec_value_v1(extra_info, %s) AS extracted_value FROM customers",
                 [term],
             )
             results = cursor.fetchall()
@@ -257,79 +234,65 @@ class TestExampleDjangoModel(unittest.TestCase):
         self.assertEqual(sorted(extracted), [1, 2, 3])
 
     def test_jsonb_field_extraction(self):
-        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
-        )
-        results = Example.objects.annotate(
-            extracted_value=CsSteVecValueV1(F("encrypted_jsonb"), Value(term))
+        term = EqlJsonb("$.num", "customers", "extra_info").to_db_format("ejson_path")
+        results = Customer.objects.annotate(
+            extracted_value=CsSteVecValueV1(F("extra_info"), Value(term))
         ).values_list("extracted_value", flat=True)
 
         extracted = [EqlJsonb.from_parsed_json(result) for result in list(results)]
 
     def test_jsonb_in_where_with_sql_clause(self):
         term1 = (
-            EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format("ejson_path"),
+            EqlJsonb("$.num", "customers", "extra_info").to_db_format("ejson_path"),
         )
-        term2 = (EqlJsonb(2, "examples", "encrypted_jsonb").to_db_format("ste_vec"),)
-        result = Example.objects.raw(
-            "SELECT * FROM examples WHERE cs_ste_vec_term_v1(encrypted_jsonb, %s) < cs_ste_vec_term_v1(%s)",
+        term2 = (EqlJsonb(2, "customers", "extra_info").to_db_format("ste_vec"),)
+        result = Customer.objects.raw(
+            "SELECT * FROM customers WHERE cs_ste_vec_term_v1(extra_info, %s) < cs_ste_vec_term_v1(%s)",
             [term1, term2],
         )[0]
 
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, result.encrypted_jsonb
-        )
+        self.assertEqual({"key": ["value"], "num": 1, "cat": "a"}, result.extra_info)
 
     def test_jsonb_in_where(self):
-        term1 = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
-        )
-        term2 = EqlJsonb(2, "examples", "encrypted_jsonb").to_db_format("ste_vec")
+        term1 = EqlJsonb("$.num", "customers", "extra_info").to_db_format("ejson_path")
+        term2 = EqlJsonb(2, "customers", "extra_info").to_db_format("ste_vec")
         query = Q(
             CsLt(
-                CsSteVecTermV1(F("encrypted_jsonb"), Value(term1)),
+                CsSteVecTermV1(F("extra_info"), Value(term1)),
                 CsSteVecTermV1(Value(term2)),
             )
         )
-        found = Example.objects.get(query)
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
-        )
+        found = Customer.objects.get(query)
+        self.assertEqual({"key": ["value"], "num": 1, "cat": "a"}, found.extra_info)
 
     def test_jsonb_field_in_order_by_with_sql_clause(self):
-        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
-        )
-        results = Example.objects.raw(
-            "SELECT * FROM examples ORDER BY cs_ste_vec_term_v1(encrypted_jsonb, %s) DESC",
+        term = EqlJsonb("$.num", "customers", "extra_info").to_db_format("ejson_path")
+        results = Customer.objects.raw(
+            "SELECT * FROM customers ORDER BY cs_ste_vec_term_v1(extra_info, %s) DESC",
             [term],
         )
-        self.assertEqual(results[0].encrypted_jsonb, {"num": 3, "cat": "b"})
-        self.assertEqual(results[1].encrypted_jsonb, {"num": 2, "cat": "b"})
+        self.assertEqual(results[0].extra_info, {"num": 3, "cat": "b"})
+        self.assertEqual(results[1].extra_info, {"num": 2, "cat": "b"})
         self.assertEqual(
-            results[2].encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"}
+            results[2].extra_info, {"key": ["value"], "num": 1, "cat": "a"}
         )
 
     def test_jsonb_field_in_order_by(self):
-        term = EqlJsonb("$.num", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
+        term = EqlJsonb("$.num", "customers", "extra_info").to_db_format("ejson_path")
+        results = Customer.objects.order_by(
+            CsSteVecTermV1(F("extra_info"), Value(term)).desc()
         )
-        results = Example.objects.order_by(
-            CsSteVecTermV1(F("encrypted_jsonb"), Value(term)).desc()
-        )
-        self.assertEqual(results[0].encrypted_jsonb, {"num": 3, "cat": "b"})
-        self.assertEqual(results[1].encrypted_jsonb, {"num": 2, "cat": "b"})
+        self.assertEqual(results[0].extra_info, {"num": 3, "cat": "b"})
+        self.assertEqual(results[1].extra_info, {"num": 2, "cat": "b"})
         self.assertEqual(
-            results[2].encrypted_jsonb, {"key": ["value"], "num": 1, "cat": "a"}
+            results[2].extra_info, {"key": ["value"], "num": 1, "cat": "a"}
         )
 
     def test_jsonb_in_group_by_with_sql_clause(self):
-        term = EqlJsonb("$.cat", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
-        )
+        term = EqlJsonb("$.cat", "customers", "extra_info").to_db_format("ejson_path")
         with connection.cursor() as cursor:
             cursor.execute(
-                "SELECT cs_grouped_value_v1(cs_ste_vec_value_v1(encrypted_jsonb, %s)) AS category, COUNT(*) FROM examples GROUP BY cs_ste_vec_term_v1(encrypted_jsonb, %s)",
+                "SELECT cs_grouped_value_v1(cs_ste_vec_value_v1(extra_info, %s)) AS category, COUNT(*) FROM customers GROUP BY cs_ste_vec_term_v1(extra_info, %s)",
                 [term, term],
             )
             results = cursor.fetchall()
@@ -341,15 +304,11 @@ class TestExampleDjangoModel(unittest.TestCase):
         self.assertEqual(sorted(counts)[1], ("b", 2))
 
     def test_jsonb_in_group_by(self):
-        term = EqlJsonb("$.cat", "examples", "encrypted_jsonb").to_db_format(
-            "ejson_path"
-        )
-        results = Example.objects.values(
-            cat=CsSteVecTermV1(F("encrypted_jsonb"), Value(term))
+        term = EqlJsonb("$.cat", "customers", "extra_info").to_db_format("ejson_path")
+        results = Customer.objects.values(
+            cat=CsSteVecTermV1(F("extra_info"), Value(term))
         ).annotate(
-            category=CsGroupedValueV1(
-                CsSteVecValueV1(F("encrypted_jsonb"), Value(term))
-            ),
+            category=CsGroupedValueV1(CsSteVecValueV1(F("extra_info"), Value(term))),
             count=Count("*"),
         )
 
@@ -360,58 +319,57 @@ class TestExampleDjangoModel(unittest.TestCase):
         self.assertEqual(result_list[1]["count"], 2)
 
 
-class Example(models.Model):
-    encrypted_int = EncryptedInt(table="examples", column="encrypted_int", null=True)
-    encrypted_boolean = EncryptedBoolean(
-        table="examples", column="encrypted_boolean", null=True
-    )
-    encrypted_date = EncryptedDate(table="examples", column="encrypted_date", null=True)
-    encrypted_float = EncryptedFloat(
-        table="examples", column="encrypted_float", null=True
-    )
-    encrypted_utf8_str = EncryptedText(
-        table="examples", column="encrypted_utf8_str", null=True
-    )
-    encrypted_jsonb = EncryptedJsonb(
-        table="examples", column="encrypted_jsonb", null=True
-    )
+class Customer(models.Model):
+    # investigate if we can remove table and column
+    age = EncryptedInt(table="customers", column="age", null=True)
+    is_citizen = EncryptedBoolean(table="customers", column="is_citizen", null=True)
+    start_date = EncryptedDate(table="customers", column="start_date", null=True)
+    weight = EncryptedFloat(table="customers", column="weight", null=True)
+    name = EncryptedText(table="customers", column="name", null=True)
+    extra_info = EncryptedJsonb(table="customers", column="extra_info", null=True)
+    visit_count = IntegerField()
 
     class Meta:
-        db_table = "examples"
+        db_table = "customers"
 
 
-class TestUnchained(unittest.TestCase):
+class TestModelWithCustomLookup(unittest.TestCase):
     def setUp(self):
-        Example.objects.all().delete()
-        self.example1, self.example2, self.example3 = create_example_records()
-        self.ex_unchained = Unchained("examples")
+        Customer.objects.all().delete()
+        self.customer1, self.customer2, self.customer3 = create_customer_records()
 
-    def test_string_equals(self):
-        found = Example.objects.get(self.ex_unchained(encrypted_utf8_str="string123"))
-        self.assertEqual(found.encrypted_utf8_str, "string123")
+    def test_text_contains_with_float_lt(self):
+        found = Customer.objects.get(name__contains="Customer", weight__lt=80.0)
+        self.assertEqual(found.weight, 55.0)
 
-    def test_string_contains(self):
-        found = Example.objects.get(
-            self.ex_unchained(encrypted_utf8_str__s_contains="yet")
-        )
-        self.assertEqual(found.encrypted_utf8_str, "yet_another")
+    def test_plaintext_lt_with_float_lt(self):
+        found = Customer.objects.get(visit_count__lte=1, weight__lt=60.0)
+        self.assertEqual(found.weight, 51.1)
 
-    def test_json_contains(self):
-        found = Example.objects.get(
-            self.ex_unchained(encrypted_jsonb__j_contains={"key": []})
-        )
-        self.assertEqual(
-            {"key": ["value"], "num": 1, "cat": "a"}, found.encrypted_jsonb
-        )
+    def test_text_exact_match(self):
+        found = Customer.objects.get(name__eq="Alice Developer")
+        self.assertEqual(found.name, "Alice Developer")
 
-    def test_greater_than(self):
-        found = Example.objects.get(self.ex_unchained(encrypted_float__gt=3.0))
-        self.assertEqual(found.encrypted_float, 5.0)
+    def test_text_partial_match(self):
+        found = Customer.objects.get(name__contains="caro")
+        self.assertEqual(found.name, "Carol Customer")
 
-    def test_less_than_and_json_contains(self):
-        found = Example.objects.get(
-            self.ex_unchained(
-                encrypted_float__lt=3.0, encrypted_jsonb__j_contains={"cat": "b"}
-            )
-        )
-        self.assertEqual(found.encrypted_float, 2.1)
+    def test_float_ore_lt(self):
+        found = Customer.objects.get(weight__lt=53.0)
+        self.assertEqual(found.weight, 51.1)
+
+    def test_float_ore_gt(self):
+        found = Customer.objects.get(weight__gt=80.0)
+        self.assertEqual(found.weight, 82.1)
+
+    def test_int_ore_lt(self):
+        found = Customer.objects.get(age__lt=30)
+        self.assertEqual(found.age, 29)
+
+    def test_int_ore_gt(self):
+        found = Customer.objects.get(age__gt=30)
+        self.assertEqual(found.age, 31)
+
+    def test_jsonb_contains(self):
+        found = Customer.objects.get(extra_info__contains={"key": []})
+        self.assertEqual(found.name, "Alice Developer")

--- a/tests/integration/support/application_types.sql
+++ b/tests/integration/support/application_types.sql
@@ -2,50 +2,50 @@
 -- Application-specific types
 --
 
-CREATE DOMAIN examples__encrypted_big_int AS cs_encrypted_v1
+CREATE DOMAIN customers__encrypted_big_int AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,t}' = 'customers' AND
     VALUE#>>'{i,c}' = 'encrypted_big_int'
 );
 
-CREATE DOMAIN examples__encrypted_boolean AS cs_encrypted_v1
+CREATE DOMAIN customers__is_citizen AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
-    VALUE#>>'{i,c}' = 'encrypted_boolean'
+    VALUE#>>'{i,t}' = 'customers' AND
+    VALUE#>>'{i,c}' = 'is_citizen'
 );
 
-CREATE DOMAIN examples__encrypted_date AS cs_encrypted_v1
+CREATE DOMAIN customers__start_date AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
-    VALUE#>>'{i,c}' = 'encrypted_date'
+    VALUE#>>'{i,t}' = 'customers' AND
+    VALUE#>>'{i,c}' = 'start_date'
 );
 
-CREATE DOMAIN examples__encrypted_float AS cs_encrypted_v1
+CREATE DOMAIN customers__weight AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
-    VALUE#>>'{i,c}' = 'encrypted_float'
+    VALUE#>>'{i,t}' = 'customers' AND
+    VALUE#>>'{i,c}' = 'weight'
 );
 
-CREATE DOMAIN examples__encrypted_int AS cs_encrypted_v1
+CREATE DOMAIN customers__age AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
-    VALUE#>>'{i,c}' = 'encrypted_int'
+    VALUE#>>'{i,t}' = 'customers' AND
+    VALUE#>>'{i,c}' = 'age'
 );
 
-CREATE DOMAIN examples__encrypted_small_int AS cs_encrypted_v1
+CREATE DOMAIN customers__encrypted_small_int AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
+    VALUE#>>'{i,t}' = 'customers' AND
     VALUE#>>'{i,c}' = 'encrypted_small_int'
 );
 
-CREATE DOMAIN examples__encrypted_utf8_str AS cs_encrypted_v1
+CREATE DOMAIN customers__name AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
-    VALUE#>>'{i,c}' = 'encrypted_utf8_str'
+    VALUE#>>'{i,t}' = 'customers' AND
+    VALUE#>>'{i,c}' = 'name'
 );
 
-CREATE DOMAIN examples__encrypted_jsonb AS cs_encrypted_v1
+CREATE DOMAIN customers__extra_info AS cs_encrypted_v1
 CHECK(
-    VALUE#>>'{i,t}' = 'examples' AND
-    VALUE#>>'{i,c}' = 'encrypted_jsonb'
+    VALUE#>>'{i,t}' = 'customers' AND
+    VALUE#>>'{i,c}' = 'extra_info'
 );

--- a/tests/integration/support/create_examples_table.sql
+++ b/tests/integration/support/create_examples_table.sql
@@ -1,32 +1,33 @@
-create table examples (
+create table customers (
   id serial primary key,
-  encrypted_boolean examples__encrypted_boolean,
-  encrypted_date examples__encrypted_date,
-  encrypted_float examples__encrypted_float,
-  encrypted_int examples__encrypted_int,
-  encrypted_utf8_str examples__encrypted_utf8_str,
-  encrypted_jsonb examples__encrypted_jsonb
+  is_citizen customers__is_citizen,
+  start_date customers__start_date,
+  weight customers__weight,
+  age customers__age,
+  name customers__name,
+  extra_info customers__extra_info,
+  visit_count integer
 );
 
 -- Add CipherStash indexes to Encrypt config
-SELECT cs_add_index_v1('examples', 'encrypted_boolean', 'ore', 'boolean');
-SELECT cs_add_index_v1('examples', 'encrypted_date', 'ore', 'date');
-SELECT cs_add_index_v1('examples', 'encrypted_float', 'ore', 'double');
-SELECT cs_add_index_v1('examples', 'encrypted_int', 'ore', 'int');
-SELECT cs_add_index_v1('examples', 'encrypted_utf8_str', 'unique', 'text', '{"token_filters": [{"kind": "downcase"}]}');
-SELECT cs_add_index_v1('examples', 'encrypted_utf8_str', 'match', 'text');
-SELECT cs_add_index_v1('examples', 'encrypted_utf8_str', 'ore', 'text');
-SELECT cs_add_index_v1('examples', 'encrypted_jsonb', 'ste_vec', 'jsonb', '{"prefix": "examples/encrypted_jsonb"}');
+SELECT cs_add_index_v1('customers', 'is_citizen', 'ore', 'boolean');
+SELECT cs_add_index_v1('customers', 'start_date', 'ore', 'date');
+SELECT cs_add_index_v1('customers', 'weight', 'ore', 'double');
+SELECT cs_add_index_v1('customers', 'age', 'ore', 'int');
+SELECT cs_add_index_v1('customers', 'name', 'unique', 'text', '{"token_filters": [{"kind": "downcase"}]}');
+SELECT cs_add_index_v1('customers', 'name', 'match', 'text');
+SELECT cs_add_index_v1('customers', 'name', 'ore', 'text');
+SELECT cs_add_index_v1('customers', 'extra_info', 'ste_vec', 'jsonb', '{"prefix": "customers/extra_info"}');
 
 -- Add corresponding PG indexes for each CipherStash index
-CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_boolean));
-CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_date));
-CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_float));
-CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_int));
-CREATE UNIQUE INDEX ON examples(cs_unique_v1(encrypted_utf8_str));
-CREATE INDEX ON examples USING GIN (cs_match_v1(encrypted_utf8_str));
-CREATE INDEX ON examples (cs_ore_64_8_v1(encrypted_utf8_str));
--- CREATE INDEX ON examples USING GIN (cs_ste_vec_v1(encrypted_jsonb));
+CREATE INDEX ON customers (cs_ore_64_8_v1(is_citizen));
+CREATE INDEX ON customers (cs_ore_64_8_v1(start_date));
+CREATE INDEX ON customers (cs_ore_64_8_v1(weight));
+CREATE INDEX ON customers (cs_ore_64_8_v1(age));
+CREATE UNIQUE INDEX ON customers(cs_unique_v1(name));
+CREATE INDEX ON customers USING GIN (cs_match_v1(name));
+CREATE INDEX ON customers (cs_ore_64_8_v1(name));
+-- CREATE INDEX ON customers USING GIN (cs_ste_vec_v1(extra_info));
 
 -- Transition the Encrypt config state from "pending", to "encrypting", and then "active".
 -- The Encrypt config must be "active" for Proxy to use it.


### PR DESCRIPTION
New simpler query interface.

It uses custom lookup to make EQL queries possible with regular Django query interfaces (with some caveats, like equality needs the `__eq` operator).

For JSON, currently there is only containment support. The rest is to be done separately.